### PR TITLE
Milestone 3: Web Features (add quit handling, export/test HTML5) Part 1

### DIFF
--- a/export/web/index.html
+++ b/export/web/index.html
@@ -111,7 +111,7 @@ body {
 
 		<script src="index.js"></script>
 		<script>
-const GODOT_CONFIG = {"args":[],"canvasResizePolicy":2,"emscriptenPoolSize":8,"ensureCrossOriginIsolationHeaders":true,"executable":"index","experimentalVK":false,"fileSizes":{"index.pck":11258128,"index.wasm":38057390},"focusCanvas":true,"gdextensionLibs":[],"godotPoolSize":4};
+const GODOT_CONFIG = {"args":[],"canvasResizePolicy":2,"emscriptenPoolSize":8,"ensureCrossOriginIsolationHeaders":true,"executable":"index","experimentalVK":false,"fileSizes":{"index.pck":11258176,"index.wasm":38057390},"focusCanvas":true,"gdextensionLibs":[],"godotPoolSize":4};
 const GODOT_THREADS_ENABLED = false;
 const engine = new Engine(GODOT_CONFIG);
 

--- a/export/web/index.html
+++ b/export/web/index.html
@@ -111,7 +111,7 @@ body {
 
 		<script src="index.js"></script>
 		<script>
-const GODOT_CONFIG = {"args":[],"canvasResizePolicy":2,"emscriptenPoolSize":8,"ensureCrossOriginIsolationHeaders":true,"executable":"index","experimentalVK":false,"fileSizes":{"index.pck":11235356,"index.wasm":38057390},"focusCanvas":true,"gdextensionLibs":[],"godotPoolSize":4};
+const GODOT_CONFIG = {"args":[],"canvasResizePolicy":2,"emscriptenPoolSize":8,"ensureCrossOriginIsolationHeaders":true,"executable":"index","experimentalVK":false,"fileSizes":{"index.pck":11258128,"index.wasm":38057390},"focusCanvas":true,"gdextensionLibs":[],"godotPoolSize":4};
 const GODOT_THREADS_ENABLED = false;
 const engine = new Engine(GODOT_CONFIG);
 

--- a/scenes/main_menu.tscn
+++ b/scenes/main_menu.tscn
@@ -1,19 +1,23 @@
-[gd_scene load_steps=12 format=3 uid="uid://brpckgp7j86jp"]
+[gd_scene load_steps=13 format=3 uid="uid://brpckgp7j86jp"]
 
 [ext_resource type="Script" uid="uid://cdubukgyitlm8" path="res://scripts/main_menu.gd" id="1_l6cm7"]
 [ext_resource type="VideoStream" uid="uid://dxu50q1yffe6a" path="res://files/video/grok-video-main2.ogv" id="2_ekxnf"]
 [ext_resource type="FontFile" uid="uid://borwvgqdgawbj" path="res://files/fonts/EMPIREST.TTF" id="3_bqqt6"]
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_oa1go"]
+bg_color = Color(0.2627451, 0.2627451, 0.2627451, 0.5882353)
+corner_radius_top_left = 20
+corner_radius_top_right = 20
+corner_radius_bottom_right = 20
+corner_radius_bottom_left = 20
+
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_rtw2f"]
-bg_color = Color(0.53333336, 0.6666667, 0.98039216, 0.5882353)
-border_width_left = 2
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
+bg_color = Color(0.2627451, 0.2627451, 0.2627451, 0.5882353)
 corner_radius_top_left = 40
 corner_radius_top_right = 40
 corner_radius_bottom_right = 40
 corner_radius_bottom_left = 40
+shadow_color = Color(0.30692267, 0.3069227, 0.3069227, 0.6)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ekxnf"]
 corner_radius_top_left = 40
@@ -33,11 +37,7 @@ shadow_size = 5
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_ekxnf"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_bqqt6"]
-bg_color = Color(0.53333336, 0.6666667, 0.98039216, 0.54901963)
-border_width_left = 2
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
+bg_color = Color(0.2627451, 0.2627451, 0.2627451, 0.5882353)
 corner_radius_top_left = 40
 corner_radius_top_right = 40
 corner_radius_bottom_right = 40
@@ -46,11 +46,7 @@ corner_radius_bottom_left = 40
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_bqqt6"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_wu84c"]
-bg_color = Color(0.53333336, 0.6666667, 0.98039216, 0.5882353)
-border_width_left = 2
-border_width_top = 2
-border_width_right = 2
-border_width_bottom = 2
+bg_color = Color(0.2627451, 0.2627451, 0.2627451, 0.5882353)
 corner_radius_top_left = 40
 corner_radius_top_right = 40
 corner_radius_bottom_right = 40
@@ -71,19 +67,31 @@ script = ExtResource("1_l6cm7")
 
 [node name="VideoStreamPlayer" type="VideoStreamPlayer" parent="."]
 layout_mode = 1
-anchors_preset = 13
-anchor_left = 0.5
-anchor_right = 0.5
+anchors_preset = 15
+anchor_right = 1.0
 anchor_bottom = 1.0
-offset_left = -232.0
-offset_right = 232.0
 grow_horizontal = 2
 grow_vertical = 2
 stream = ExtResource("2_ekxnf")
 autoplay = true
 loop = true
 
-[node name="VBoxContainer" type="VBoxContainer" parent="VideoStreamPlayer"]
+[node name="Panel" type="Panel" parent="VideoStreamPlayer"]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -180.0
+offset_top = -115.0
+offset_right = 180.0
+offset_bottom = 115.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_oa1go")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="VideoStreamPlayer/Panel"]
 layout_mode = 1
 anchors_preset = 8
 anchor_left = 0.5
@@ -98,7 +106,7 @@ grow_horizontal = 2
 grow_vertical = 2
 theme_override_constants/separation = 6
 
-[node name="Label" type="Label" parent="VideoStreamPlayer/VBoxContainer"]
+[node name="Label" type="Label" parent="VideoStreamPlayer/Panel/VBoxContainer"]
 visible = false
 layout_mode = 2
 size_flags_vertical = 3
@@ -107,10 +115,10 @@ text = "Sky Lock Assault"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="StartButton" type="Button" parent="VideoStreamPlayer/VBoxContainer"]
+[node name="StartButton" type="Button" parent="VideoStreamPlayer/Panel/VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 3
-theme_override_colors/font_color = Color(0.023529412, 0.023529412, 0, 1)
+theme_override_colors/font_color = Color(0.9913891, 0.21623385, 0.27923363, 1)
 theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
 theme_override_colors/font_hover_color = Color(0.9607843, 0.9607843, 0.050980393, 1)
 theme_override_fonts/font = ExtResource("3_bqqt6")
@@ -121,10 +129,10 @@ theme_override_styles/hover = SubResource("StyleBoxFlat_8ln24")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_ekxnf")
 text = "{START=GAME}"
 
-[node name="OptionsButton" type="Button" parent="VideoStreamPlayer/VBoxContainer"]
+[node name="OptionsButton" type="Button" parent="VideoStreamPlayer/Panel/VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 3
-theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_colors/font_color = Color(0.99215686, 0.21568628, 0.2784314, 1)
 theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
 theme_override_colors/font_hover_color = Color(0.9607843, 0.9607843, 0.050980393, 1)
 theme_override_fonts/font = ExtResource("3_bqqt6")
@@ -135,10 +143,10 @@ theme_override_styles/hover = SubResource("StyleBoxFlat_8ln24")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_bqqt6")
 text = "{OPTIONS}"
 
-[node name="QuitButton" type="Button" parent="VideoStreamPlayer/VBoxContainer"]
+[node name="QuitButton" type="Button" parent="VideoStreamPlayer/Panel/VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 3
-theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_colors/font_color = Color(0.99215686, 0.21568628, 0.2784314, 1)
 theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
 theme_override_colors/font_hover_color = Color(0.9607843, 0.9607843, 0.050980393, 1)
 theme_override_fonts/font = ExtResource("3_bqqt6")
@@ -149,10 +157,10 @@ theme_override_styles/hover = SubResource("StyleBoxFlat_8ln24")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_wu84c")
 text = "{QUIT}"
 
-[node name="QuitDialog" type="ConfirmationDialog" parent="VideoStreamPlayer/VBoxContainer"]
+[node name="QuitDialog" type="ConfirmationDialog" parent="VideoStreamPlayer/Panel/VBoxContainer"]
 oversampling_override = 1.0
 title = "Quit Game?"
 size = Vector2i(383, 100)
 dialog_text = "Are you sure you want to quit Sky Lock Assault?"
 
-[connection signal="confirmed" from="VideoStreamPlayer/VBoxContainer/QuitDialog" to="." method="_on_quit_dialog_confirmed"]
+[connection signal="confirmed" from="VideoStreamPlayer/Panel/VBoxContainer/QuitDialog" to="." method="_on_quit_dialog_confirmed"]

--- a/scenes/options.tscn
+++ b/scenes/options.tscn
@@ -1,9 +1,0 @@
-[gd_scene format=3 uid="uid://ckky6bjxngluo"]
-
-[node name="Options" type="Control"]
-layout_mode = 3
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2

--- a/scenes/options_menu.tscn
+++ b/scenes/options_menu.tscn
@@ -1,9 +1,17 @@
-[gd_scene load_steps=7 format=3 uid="uid://cl4m4q2eurcn0"]
+[gd_scene load_steps=8 format=3 uid="uid://cl4m4q2eurcn0"]
 
 [ext_resource type="Script" uid="uid://cajq8hf84eplh" path="res://scripts/options_menu.gd" id="1_ijpji"]
 [ext_resource type="FontFile" uid="uid://borwvgqdgawbj" path="res://files/fonts/EMPIREST.TTF" id="1_liyum"]
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_lfjc7"]
+bg_color = Color(0.2627451, 0.2627451, 0.2627451, 0.5882353)
+corner_radius_top_left = 20
+corner_radius_top_right = 20
+corner_radius_bottom_right = 20
+corner_radius_bottom_left = 20
+
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_liyum"]
+bg_color = Color(0.2627451, 0.2627451, 0.2627451, 0.5882353)
 corner_radius_top_left = 40
 corner_radius_top_right = 40
 corner_radius_bottom_right = 40
@@ -16,53 +24,61 @@ corner_radius_bottom_right = 40
 corner_radius_bottom_left = 40
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_hm4m4"]
+bg_color = Color(0.53333336, 0.6666667, 0.98039216, 0.3137255)
 corner_radius_top_left = 40
 corner_radius_top_right = 40
 corner_radius_bottom_right = 40
 corner_radius_bottom_left = 40
+shadow_size = 5
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_lfjc7"]
 
-[node name="OptionsMenu" type="Control"]
-layout_mode = 3
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-grow_horizontal = 2
-grow_vertical = 2
+[node name="OptionsMenu" type="CanvasLayer"]
 script = ExtResource("1_ijpji")
 
-[node name="VBoxContainer" type="VBoxContainer" parent="."]
-layout_mode = 1
+[node name="Panel" type="Panel" parent="."]
 anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = -20.0
-offset_top = -20.0
-offset_right = 20.0
-offset_bottom = 20.0
+offset_left = -185.0
+offset_top = -100.0
+offset_right = 185.0
+offset_bottom = 100.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_lfjc7")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -140.0
+offset_top = -81.0
+offset_right = 140.0
+offset_bottom = 80.0
 grow_horizontal = 2
 grow_vertical = 2
 
 [node name="Label" type="Label" parent="VBoxContainer"]
 layout_mode = 2
+size_flags_vertical = 6
 theme_override_colors/font_color = Color(0.9607843, 0.9607843, 0.050980393, 1)
 theme_override_fonts/font = ExtResource("1_liyum")
-theme_override_font_sizes/font_size = 45
+theme_override_font_sizes/font_size = 50
 text = "{OPTIONS}"
 
 [node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
 layout_mode = 2
-size_flags_vertical = 4
+size_flags_vertical = 6
 
 [node name="Label" type="Label" parent="VBoxContainer/HBoxContainer"]
 layout_mode = 2
 theme_override_fonts/font = ExtResource("1_liyum")
-theme_override_font_sizes/font_size = 20
+theme_override_font_sizes/font_size = 25
 text = "{LOG=LEVEL}"
 
 [node name="LogLevelOptionButton" type="OptionButton" parent="VBoxContainer/HBoxContainer"]
@@ -70,6 +86,10 @@ layout_mode = 2
 
 [node name="BackButton" type="Button" parent="VBoxContainer"]
 layout_mode = 2
+size_flags_vertical = 3
+theme_override_colors/font_color = Color(0.99215686, 0.21568628, 0.2784314, 1)
+theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
+theme_override_colors/font_hover_color = Color(0.9607843, 0.9607843, 0.050980393, 1)
 theme_override_fonts/font = ExtResource("1_liyum")
 theme_override_font_sizes/font_size = 35
 theme_override_styles/normal = SubResource("StyleBoxFlat_liyum")

--- a/scenes/options_menu.tscn
+++ b/scenes/options_menu.tscn
@@ -1,0 +1,79 @@
+[gd_scene load_steps=7 format=3 uid="uid://cl4m4q2eurcn0"]
+
+[ext_resource type="Script" uid="uid://cajq8hf84eplh" path="res://scripts/options_menu.gd" id="1_ijpji"]
+[ext_resource type="FontFile" uid="uid://borwvgqdgawbj" path="res://files/fonts/EMPIREST.TTF" id="1_liyum"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_liyum"]
+corner_radius_top_left = 40
+corner_radius_top_right = 40
+corner_radius_bottom_right = 40
+corner_radius_bottom_left = 40
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ijpji"]
+corner_radius_top_left = 40
+corner_radius_top_right = 40
+corner_radius_bottom_right = 40
+corner_radius_bottom_left = 40
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_hm4m4"]
+corner_radius_top_left = 40
+corner_radius_top_right = 40
+corner_radius_bottom_right = 40
+corner_radius_bottom_left = 40
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_lfjc7"]
+
+[node name="OptionsMenu" type="Control"]
+layout_mode = 3
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_ijpji")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -20.0
+offset_top = -20.0
+offset_right = 20.0
+offset_bottom = 20.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Label" type="Label" parent="VBoxContainer"]
+layout_mode = 2
+theme_override_colors/font_color = Color(0.9607843, 0.9607843, 0.050980393, 1)
+theme_override_fonts/font = ExtResource("1_liyum")
+theme_override_font_sizes/font_size = 45
+text = "{OPTIONS}"
+
+[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 4
+
+[node name="Label" type="Label" parent="VBoxContainer/HBoxContainer"]
+layout_mode = 2
+theme_override_fonts/font = ExtResource("1_liyum")
+theme_override_font_sizes/font_size = 20
+text = "{LOG=LEVEL}"
+
+[node name="LogLevelOptionButton" type="OptionButton" parent="VBoxContainer/HBoxContainer"]
+layout_mode = 2
+
+[node name="BackButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+theme_override_fonts/font = ExtResource("1_liyum")
+theme_override_font_sizes/font_size = 35
+theme_override_styles/normal = SubResource("StyleBoxFlat_liyum")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_ijpji")
+theme_override_styles/hover = SubResource("StyleBoxFlat_hm4m4")
+theme_override_styles/focus = SubResource("StyleBoxEmpty_lfjc7")
+text = "{BACK}"

--- a/scenes/pause_menu.tscn
+++ b/scenes/pause_menu.tscn
@@ -1,73 +1,31 @@
-[gd_scene load_steps=11 format=3 uid="uid://cb4n4cqkuddqg"]
+[gd_scene load_steps=7 format=3 uid="uid://cb4n4cqkuddqg"]
 
 [ext_resource type="Script" uid="uid://jdb4e3uytiw1" path="res://scripts/pause_menu.gd" id="1_n87rw"]
 [ext_resource type="FontFile" uid="uid://borwvgqdgawbj" path="res://files/fonts/EMPIREST.TTF" id="2_myx47"]
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_n87rw"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_1s2dm"]
 bg_color = Color(0.53333336, 0.6666667, 0.98039216, 0.5882353)
 corner_radius_top_left = 40
 corner_radius_top_right = 40
 corner_radius_bottom_right = 40
 corner_radius_bottom_left = 40
-shadow_size = 2
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_kukqi"]
-content_margin_left = 4.0
-content_margin_top = 4.0
-content_margin_right = 4.0
-content_margin_bottom = 4.0
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_88e76"]
 corner_radius_top_left = 40
 corner_radius_top_right = 40
 corner_radius_bottom_right = 40
 corner_radius_bottom_left = 40
-corner_detail = 5
 
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_5d2l8"]
-content_margin_left = 4.0
-content_margin_top = 4.0
-content_margin_right = 4.0
-content_margin_bottom = 4.0
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_knqa7"]
 bg_color = Color(0.53333336, 0.6666667, 0.98039216, 0.3137255)
+border_color = Color(0.20871013, 0.20871016, 0.20870999, 1)
 corner_radius_top_left = 40
 corner_radius_top_right = 40
 corner_radius_bottom_right = 40
 corner_radius_bottom_left = 40
-corner_detail = 5
+shadow_size = 5
 
-[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_n87rw"]
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_myx47"]
-bg_color = Color(0.53333336, 0.6666667, 0.98039216, 0.5882353)
-corner_radius_top_left = 40
-corner_radius_top_right = 40
-corner_radius_bottom_right = 40
-corner_radius_bottom_left = 40
-shadow_size = 2
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_7l7mv"]
-content_margin_left = 4.0
-content_margin_top = 4.0
-content_margin_right = 4.0
-content_margin_bottom = 4.0
-corner_radius_top_left = 40
-corner_radius_top_right = 40
-corner_radius_bottom_right = 40
-corner_radius_bottom_left = 40
-corner_detail = 5
-
-[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_v4r4p"]
-content_margin_left = 4.0
-content_margin_top = 4.0
-content_margin_right = 4.0
-content_margin_bottom = 4.0
-bg_color = Color(0.53333336, 0.6666667, 0.98039216, 0.3137255)
-corner_radius_top_left = 40
-corner_radius_top_right = 40
-corner_radius_bottom_right = 40
-corner_radius_bottom_left = 40
-corner_detail = 5
-
-[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_myx47"]
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_71k7c"]
 
 [node name="Control" type="CanvasLayer"]
 process_mode = 3
@@ -82,7 +40,7 @@ anchor_bottom = 0.5
 offset_left = -225.0
 offset_top = -100.0
 offset_right = 225.0
-offset_bottom = 50.0
+offset_bottom = 100.0
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_constants/separation = 6
@@ -104,11 +62,25 @@ theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
 theme_override_colors/font_hover_color = Color(0.9607843, 0.9607843, 0.050980393, 1)
 theme_override_fonts/font = ExtResource("2_myx47")
 theme_override_font_sizes/font_size = 35
-theme_override_styles/normal = SubResource("StyleBoxFlat_n87rw")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_kukqi")
-theme_override_styles/hover = SubResource("StyleBoxFlat_5d2l8")
-theme_override_styles/focus = SubResource("StyleBoxEmpty_n87rw")
+theme_override_styles/normal = SubResource("StyleBoxFlat_1s2dm")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_88e76")
+theme_override_styles/hover = SubResource("StyleBoxFlat_knqa7")
+theme_override_styles/focus = SubResource("StyleBoxEmpty_71k7c")
 text = "{BACK=TO=MAIN=MENU}"
+
+[node name="OptionsButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
+theme_override_colors/font_hover_color = Color(0.9607843, 0.9607843, 0.050980393, 1)
+theme_override_fonts/font = ExtResource("2_myx47")
+theme_override_font_sizes/font_size = 35
+theme_override_styles/normal = SubResource("StyleBoxFlat_1s2dm")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_88e76")
+theme_override_styles/hover = SubResource("StyleBoxFlat_knqa7")
+theme_override_styles/focus = SubResource("StyleBoxEmpty_71k7c")
+text = "{OPTIONS}"
 
 [node name="ResumeButton" type="Button" parent="VBoxContainer"]
 layout_mode = 2
@@ -118,8 +90,10 @@ theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
 theme_override_colors/font_hover_color = Color(0.9607843, 0.9607843, 0.050980393, 1)
 theme_override_fonts/font = ExtResource("2_myx47")
 theme_override_font_sizes/font_size = 35
-theme_override_styles/normal = SubResource("StyleBoxFlat_myx47")
-theme_override_styles/pressed = SubResource("StyleBoxFlat_7l7mv")
-theme_override_styles/hover = SubResource("StyleBoxFlat_v4r4p")
-theme_override_styles/focus = SubResource("StyleBoxEmpty_myx47")
+theme_override_styles/normal = SubResource("StyleBoxFlat_1s2dm")
+theme_override_styles/pressed = SubResource("StyleBoxFlat_88e76")
+theme_override_styles/hover = SubResource("StyleBoxFlat_knqa7")
+theme_override_styles/focus = SubResource("StyleBoxEmpty_71k7c")
 text = "{RESUME}"
+
+[connection signal="pressed" from="VBoxContainer/OptionsButton" to="." method="_on_options_button_pressed"]

--- a/scenes/pause_menu.tscn
+++ b/scenes/pause_menu.tscn
@@ -1,14 +1,22 @@
-[gd_scene load_steps=7 format=3 uid="uid://cb4n4cqkuddqg"]
+[gd_scene load_steps=8 format=3 uid="uid://cb4n4cqkuddqg"]
 
 [ext_resource type="Script" uid="uid://jdb4e3uytiw1" path="res://scripts/pause_menu.gd" id="1_n87rw"]
 [ext_resource type="FontFile" uid="uid://borwvgqdgawbj" path="res://files/fonts/EMPIREST.TTF" id="2_myx47"]
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_myx47"]
+bg_color = Color(0.2627451, 0.2627451, 0.2627451, 0.5882353)
+corner_radius_top_left = 20
+corner_radius_top_right = 20
+corner_radius_bottom_right = 20
+corner_radius_bottom_left = 20
+
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_1s2dm"]
-bg_color = Color(0.53333336, 0.6666667, 0.98039216, 0.5882353)
+bg_color = Color(0.2627451, 0.2627451, 0.2627451, 0.5882353)
 corner_radius_top_left = 40
 corner_radius_top_right = 40
 corner_radius_bottom_right = 40
 corner_radius_bottom_left = 40
+shadow_color = Color(0, 0, 0, 0.27058825)
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_88e76"]
 corner_radius_top_left = 40
@@ -31,15 +39,29 @@ shadow_size = 5
 process_mode = 3
 script = ExtResource("1_n87rw")
 
+[node name="Panel" type="Panel" parent="."]
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -195.0
+offset_top = -120.0
+offset_right = 195.0
+offset_bottom = 120.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_myx47")
+
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = -225.0
+offset_left = -175.0
 offset_top = -100.0
-offset_right = 225.0
+offset_right = 175.0
 offset_bottom = 100.0
 grow_horizontal = 2
 grow_vertical = 2
@@ -57,7 +79,7 @@ horizontal_alignment = 1
 [node name="BackToMainButton" type="Button" parent="VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 3
-theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_colors/font_color = Color(0.99215686, 0.21568628, 0.2784314, 1)
 theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
 theme_override_colors/font_hover_color = Color(0.9607843, 0.9607843, 0.050980393, 1)
 theme_override_fonts/font = ExtResource("2_myx47")
@@ -66,12 +88,12 @@ theme_override_styles/normal = SubResource("StyleBoxFlat_1s2dm")
 theme_override_styles/pressed = SubResource("StyleBoxFlat_88e76")
 theme_override_styles/hover = SubResource("StyleBoxFlat_knqa7")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_71k7c")
-text = "{BACK=TO=MAIN=MENU}"
+text = "{MAIN=MENU}"
 
 [node name="OptionsButton" type="Button" parent="VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 3
-theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_colors/font_color = Color(0.99215686, 0.21568628, 0.2784314, 1)
 theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
 theme_override_colors/font_hover_color = Color(0.9607843, 0.9607843, 0.050980393, 1)
 theme_override_fonts/font = ExtResource("2_myx47")
@@ -85,7 +107,7 @@ text = "{OPTIONS}"
 [node name="ResumeButton" type="Button" parent="VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 3
-theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_colors/font_color = Color(0.99215686, 0.21568628, 0.2784314, 1)
 theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
 theme_override_colors/font_hover_color = Color(0.9607843, 0.9607843, 0.050980393, 1)
 theme_override_fonts/font = ExtResource("2_myx47")

--- a/scripts/globals.gd
+++ b/scripts/globals.gd
@@ -19,15 +19,17 @@ func _ready() -> void:
 	# In _ready(), add after initial log level set:
 	_load_settings()  # If not already; loads log level and could expand for more
 
+
 # Add these new functions (for consistency with log level persistence)
 func _load_settings() -> void:
 	var config: ConfigFile = ConfigFile.new()
-	var err:= config.load("user://settings.cfg")
+	var err := config.load("user://settings.cfg")
 	if err == OK:
 		current_log_level = config.get_value("Settings", "log_level", LogLevel.INFO)
 		log_message("Loaded saved log level: " + LogLevel.keys()[current_log_level], LogLevel.INFO)
 	else:
 		log_message("No saved settings found—using default.", LogLevel.DEBUG)
+
 
 # In globals.gd (add after _load_settings())
 func load_options() -> void:
@@ -38,6 +40,7 @@ func load_options() -> void:
 		get_tree().change_scene_to_packed(options_scene)
 	else:
 		log_message("Error: Options scene not found!", LogLevel.ERROR)
+
 
 # Custom logging function with timestamp and level filtering.
 # @param message: The string message to log.

--- a/scripts/globals.gd
+++ b/scripts/globals.gd
@@ -24,3 +24,17 @@ func log_message(message: String, level: LogLevel = LogLevel.INFO) -> void:
 	var level_str: String = LogLevel.keys()[level]  # Converts enum to string: "INFO", etc.
 	var timestamp: String = Time.get_datetime_string_from_system()
 	print("[%s] [%s] %s" % [timestamp, level_str, message])
+	
+# Override to handle engine notifications, like window close requests.
+# @param what: The notification ID (int constant from Godot).
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_WM_CLOSE_REQUEST:
+ 		# Cleanup logic here—runs just before quit.
+		log_message("Window close requested—performing cleanup...", LogLevel.INFO)
+		
+		# Example: Save game state if you have a save system.
+		# Replace with your actual save function, e.g., from a save_manager.gd.
+		# save_game_state()  # Uncomment and implement as needed.
+		
+		# After cleanup, let the quit proceed (optional on desktop; auto on web).
+		get_tree().quit()

--- a/scripts/globals.gd
+++ b/scripts/globals.gd
@@ -2,7 +2,7 @@ extends Node
 
 # Global utilities singleton: Provides shared functions like logging.
 # Access from any script as Globals.log_message("message").
-enum LogLevel { DEBUG, INFO, WARNING, ERROR, NONE }
+enum LogLevel { DEBUG, INFO, WARNING, ERROR, NONE = 4 }
 @export var current_log_level: LogLevel = LogLevel.INFO  # Default: Show INFO and above
 @export var enable_debug_logging: bool = false  # Toggle in Inspector or settings
 
@@ -38,18 +38,6 @@ func load_options() -> void:
 	if options_scene:
 		var options_inst := options_scene.instantiate()
 		get_tree().root.add_child(options_inst)  # Add to root (on top)
-	else:
-		log_message("Error: Options scene not found!", LogLevel.ERROR)
-
-
-# In globals.gd (add after _load_settings())
-func _load_options() -> void:
-	previous_scene = get_tree().current_scene.scene_file_path  # Store current path
-	log_message("Loading options menu from: " + previous_scene, LogLevel.DEBUG)
-	get_tree().paused = false  # Unpause tree before change (key fix)
-	var options_scene: PackedScene = preload("res://scenes/options_menu.tscn")
-	if options_scene:
-		get_tree().change_scene_to_packed(options_scene)
 	else:
 		log_message("Error: Options scene not found!", LogLevel.ERROR)
 

--- a/scripts/globals.gd
+++ b/scripts/globals.gd
@@ -31,8 +31,19 @@ func _load_settings() -> void:
 		log_message("No saved settings found—using default.", LogLevel.DEBUG)
 
 
-# In globals.gd (add after _load_settings())
+# In globals.gd (load_options())
 func load_options() -> void:
+	log_message("Instancing options menu over current scene.", LogLevel.DEBUG)
+	var options_scene: PackedScene = preload("res://scenes/options_menu.tscn")
+	if options_scene:
+		var options_inst: = options_scene.instantiate()
+		get_tree().root.add_child(options_inst)  # Add to root (on top)
+	else:
+		log_message("Error: Options scene not found!", LogLevel.ERROR)
+
+
+# In globals.gd (add after _load_settings())
+func _load_options() -> void:
 	previous_scene = get_tree().current_scene.scene_file_path  # Store current path
 	log_message("Loading options menu from: " + previous_scene, LogLevel.DEBUG)
 	get_tree().paused = false  # Unpause tree before change (key fix)

--- a/scripts/globals.gd
+++ b/scripts/globals.gd
@@ -36,7 +36,7 @@ func load_options() -> void:
 	log_message("Instancing options menu over current scene.", LogLevel.DEBUG)
 	var options_scene: PackedScene = preload("res://scenes/options_menu.tscn")
 	if options_scene:
-		var options_inst: = options_scene.instantiate()
+		var options_inst := options_scene.instantiate()
 		get_tree().root.add_child(options_inst)  # Add to root (on top)
 	else:
 		log_message("Error: Options scene not found!", LogLevel.ERROR)

--- a/scripts/globals.gd
+++ b/scripts/globals.gd
@@ -35,6 +35,7 @@ func _load_settings() -> void:
 func load_options() -> void:
 	previous_scene = get_tree().current_scene.scene_file_path  # Store current path
 	log_message("Loading options menu from: " + previous_scene, LogLevel.DEBUG)
+	get_tree().paused = false  # Unpause tree before change (key fix)
 	var options_scene: PackedScene = preload("res://scenes/options_menu.tscn")
 	if options_scene:
 		get_tree().change_scene_to_packed(options_scene)

--- a/scripts/globals.gd
+++ b/scripts/globals.gd
@@ -2,7 +2,7 @@ extends Node
 
 # Global utilities singleton: Provides shared functions like logging.
 # Access from any script as Globals.log_message("message").
-enum LogLevel { DEBUG, INFO, WARNING, ERROR }
+enum LogLevel { DEBUG, INFO, WARNING, ERROR, NONE }
 @export var current_log_level: LogLevel = LogLevel.INFO  # Default: Show INFO and above
 @export var enable_debug_logging: bool = false  # Toggle in Inspector or settings
 

--- a/scripts/main_menu.gd
+++ b/scripts/main_menu.gd
@@ -1,16 +1,17 @@
 extends Control
 
 # Default relative path; override in Inspector if needed
-@export var quit_dialog_path: NodePath = NodePath("VideoStreamPlayer/VBoxContainer/QuitDialog")
+@export var quit_dialog_path: NodePath = NodePath("VideoStreamPlayer/Panel/VBoxContainer/QuitDialog")
 # Reference to the quit dialog node, assigned in setup_quit_dialog or _ready()
 var quit_dialog: ConfirmationDialog
 var game_scene: PackedScene = preload("res://scenes/main_scene.tscn")
 var options_menu: PackedScene = preload("res://scenes/options_menu.tscn")
 
-@onready var ui_container: VBoxContainer = $VideoStreamPlayer/VBoxContainer
-@onready var start_button: Button = $VideoStreamPlayer/VBoxContainer/StartButton
-@onready var options_button: Button = $VideoStreamPlayer/VBoxContainer/OptionsButton
-@onready var quit_button: Button = $VideoStreamPlayer/VBoxContainer/QuitButton
+@onready var ui_panel: Panel = $VideoStreamPlayer/Panel
+@onready var ui_container: VBoxContainer = $VideoStreamPlayer/Panel/VBoxContainer
+@onready var start_button: Button = $VideoStreamPlayer/Panel/VBoxContainer/StartButton
+@onready var options_button: Button = $VideoStreamPlayer/Panel/VBoxContainer/OptionsButton
+@onready var quit_button: Button = $VideoStreamPlayer/Panel/VBoxContainer/QuitButton
 
 # Handles the main menu UI, including button connections and quit dialog logic.
 # This script manages scene transitions and platform-specific quitting for web/desktop.
@@ -27,21 +28,33 @@ func _ready() -> void:
 	setup_quit_dialog()  # New: Handles dialog setup in one place
 	# assert(quit_dialog != null, "QuitDialog must be assigned!")
 	# Hide UI initially (buttons and dialog won't show right away)
+	ui_panel.modulate.a = 0.0  # Start fully transparent for fade-in
+	ui_panel.visible = false  # Or just hide if no fade needed
 	ui_container.modulate.a = 0.0  # Start fully transparent for fade-in
 	ui_container.visible = false  # Or just hide if no fade needed
 
 	# New: Create and start a timer for delayed UI show
 	var delay_timer: Timer = Timer.new()
-	delay_timer.wait_time = 1.0  # Delay in seconds (change to 5.0 for longer)
+	delay_timer.wait_time = 0.5  # Delay in seconds (change to 5.0 for longer)
 	delay_timer.one_shot = true  # Runs once
 	add_child(delay_timer)  # Add to scene tree
-	delay_timer.timeout.connect(_show_ui)  # Connect to show function
+	delay_timer.timeout.connect(_show_ui_panel)  # Connect to show function
 	delay_timer.start()
-	Globals.log_message("Starting UI delay timer...", Globals.LogLevel.DEBUG)
-
+	Globals.log_message("Starting UI delay timer #1...", Globals.LogLevel.DEBUG)
+	
+	delay_timer.timeout.connect(_show_ui_container)
+	delay_timer.start()
+	Globals.log_message("Starting UI delay timer #2...", Globals.LogLevel.DEBUG)
 
 # New: Function to reveal the UI after delay (with optional fade-in)
-func _show_ui() -> void:
+func _show_ui_panel() -> void:
+	ui_panel.visible = true  # Make visible
+	# Optional: Fade in over 1 second for smooth effect (learning Tween basics)
+	var tween: Tween = create_tween()
+	tween.tween_property(ui_panel, "modulate:a", 1.0, 1.0)  # From current alpha to 1.0
+	Globals.log_message("Showing main menu UI after delay.", Globals.LogLevel.DEBUG)
+
+func _show_ui_container() -> void:
 	ui_container.visible = true  # Make visible
 	# Optional: Fade in over 1 second for smooth effect (learning Tween basics)
 	var tween: Tween = create_tween()

--- a/scripts/main_menu.gd
+++ b/scripts/main_menu.gd
@@ -43,20 +43,23 @@ func _ready() -> void:
 	delay_timer.start()
 	Globals.log_message("Starting initial delay timer...", Globals.LogLevel.DEBUG)
 
+
 # New: Starts the sequenced fades after delay
 func _start_ui_fade() -> void:
 	ui_panel.visible = true  # Make visible before fade
-	var tween:= create_tween()  # Node-specific Tween (auto-frees on finish)
+	var tween := create_tween()  # Node-specific Tween (auto-frees on finish)
 	tween.tween_property(ui_panel, "modulate:a", 1.0, 0.5)  # Fade panel over 0.5s
 	tween.tween_callback(_fade_ui_container)  # Chain: Call next after panel fade
 	Globals.log_message("Fading in UI panel.", Globals.LogLevel.DEBUG)
 
+
 # New: Fades ui_container after panel
 func _fade_ui_container() -> void:
 	ui_container.visible = true
-	var tween:= create_tween()
+	var tween := create_tween()
 	tween.tween_property(ui_container, "modulate:a", 1.0, 0.3)  # Shorter fade for container
 	Globals.log_message("Fading in UI container.", Globals.LogLevel.DEBUG)
+
 
 # Connect dialog signals (can also do this in editor; add null check)
 func setup_quit_dialog() -> void:

--- a/scripts/main_menu.gd
+++ b/scripts/main_menu.gd
@@ -34,33 +34,29 @@ func _ready() -> void:
 	ui_container.visible = false  # Or just hide if no fade needed
 
 	# New: Create and start a timer for delayed UI show
-	var delay_timer: Timer = Timer.new()
-	delay_timer.wait_time = 0.5  # Delay in seconds (change to 5.0 for longer)
-	delay_timer.one_shot = true  # Runs once
-	add_child(delay_timer)  # Add to scene tree
-	delay_timer.timeout.connect(_show_ui_panel)  # Connect to show function
+	# In _ready() (replace timer; no Timer needed)
+	var delay_timer: Timer = Timer.new()  # Still use timer for initial delay
+	delay_timer.wait_time = 0.5
+	delay_timer.one_shot = true
+	add_child(delay_timer)
+	delay_timer.timeout.connect(_start_ui_fade)
 	delay_timer.start()
-	Globals.log_message("Starting UI delay timer #1...", Globals.LogLevel.DEBUG)
-	
-	delay_timer.timeout.connect(_show_ui_container)
-	delay_timer.start()
-	Globals.log_message("Starting UI delay timer #2...", Globals.LogLevel.DEBUG)
+	Globals.log_message("Starting initial delay timer...", Globals.LogLevel.DEBUG)
 
-# New: Function to reveal the UI after delay (with optional fade-in)
-func _show_ui_panel() -> void:
-	ui_panel.visible = true  # Make visible
-	# Optional: Fade in over 1 second for smooth effect (learning Tween basics)
-	var tween: Tween = create_tween()
-	tween.tween_property(ui_panel, "modulate:a", 1.0, 1.0)  # From current alpha to 1.0
-	Globals.log_message("Showing main menu UI after delay.", Globals.LogLevel.DEBUG)
+# New: Starts the sequenced fades after delay
+func _start_ui_fade() -> void:
+	ui_panel.visible = true  # Make visible before fade
+	var tween:= create_tween()  # Node-specific Tween (auto-frees on finish)
+	tween.tween_property(ui_panel, "modulate:a", 1.0, 0.5)  # Fade panel over 0.5s
+	tween.tween_callback(_fade_ui_container)  # Chain: Call next after panel fade
+	Globals.log_message("Fading in UI panel.", Globals.LogLevel.DEBUG)
 
-func _show_ui_container() -> void:
-	ui_container.visible = true  # Make visible
-	# Optional: Fade in over 1 second for smooth effect (learning Tween basics)
-	var tween: Tween = create_tween()
-	tween.tween_property(ui_container, "modulate:a", 1.0, 1.0)  # From current alpha to 1.0
-	Globals.log_message("Showing main menu UI after delay.", Globals.LogLevel.DEBUG)
-
+# New: Fades ui_container after panel
+func _fade_ui_container() -> void:
+	ui_container.visible = true
+	var tween:= create_tween()
+	tween.tween_property(ui_container, "modulate:a", 1.0, 0.3)  # Shorter fade for container
+	Globals.log_message("Fading in UI container.", Globals.LogLevel.DEBUG)
 
 # Connect dialog signals (can also do this in editor; add null check)
 func setup_quit_dialog() -> void:

--- a/scripts/main_menu.gd
+++ b/scripts/main_menu.gd
@@ -5,6 +5,7 @@ extends Control
 # Reference to the quit dialog node, assigned in setup_quit_dialog or _ready()
 var quit_dialog: ConfirmationDialog
 var game_scene: PackedScene = preload("res://scenes/main_scene.tscn")
+var options_menu: PackedScene = preload("res://scenes/options_menu.tscn")
 
 @onready var ui_container: VBoxContainer = $VideoStreamPlayer/VBoxContainer
 @onready var start_button: Button = $VideoStreamPlayer/VBoxContainer/StartButton
@@ -21,7 +22,7 @@ func _ready() -> void:
 	Globals.log_message("Initializing main menu...", Globals.LogLevel.DEBUG)
 
 	start_button.pressed.connect(_on_start_pressed)
-	options_button.pressed.connect(_on_options_pressed)
+	options_button.pressed.connect(_on_options_button_pressed)
 	quit_button.pressed.connect(_on_quit_pressed)
 	setup_quit_dialog()  # New: Handles dialog setup in one place
 	# assert(quit_dialog != null, "QuitDialog must be assigned!")
@@ -85,12 +86,8 @@ func _on_start_pressed() -> void:
 
 # Handles the Options button press.
 # Placeholder for loading an options scene.
-func _on_options_pressed() -> void:
-	# Stub; later: get_tree().change_scene_to_file("res://options_scene.tscn")
-	Globals.log_message("Options menu coming soon!", Globals.LogLevel.DEBUG)
-	# Future:
-	# var options_scene = preload("res://scenes/options_scene.tscn");
-	# get_tree().change_scene_to_packed(options_scene)
+func _on_options_button_pressed() -> void:
+	Globals.load_options()
 
 
 # Handles the Quit button press.

--- a/scripts/options_menu.gd
+++ b/scripts/options_menu.gd
@@ -1,0 +1,50 @@
+extends Control
+
+@onready var log_lvl_option: OptionButton = $VBoxContainer/HBoxContainer/LogLevelOptionButton
+@onready var back_button: Button = $VBoxContainer/BackButton
+
+func _ready() -> void:
+	# Populate OptionButton with all LogLevel enum values
+	for level: String in Globals.LogLevel.keys():
+		log_lvl_option.add_item(level)
+	
+	# Set to current log level (find index by enum value)
+	var current_value: int = Globals.current_log_level
+	var index: int = Globals.LogLevel.values().find(current_value)
+	if index != -1:
+		log_lvl_option.selected = index
+	else:
+		log_lvl_option.selected = 1  # Fallback to INFO (index 1)
+		Globals.log_message("Invalid saved log level—reset to INFO.", Globals.LogLevel.WARNING)
+	
+	# Connect signals
+	log_lvl_option.item_selected.connect(_on_log_selected)
+	back_button.pressed.connect(_on_back_pressed)
+	
+	Globals.log_message("Options menu loaded.", Globals.LogLevel.DEBUG)
+
+# Handles log level selection change
+# Update _on_log_selected to use the selected name for enum lookup:
+func _on_log_selected(index: int) -> void:
+	var selected_name: String = log_lvl_option.get_item_text(index)
+	Globals.current_log_level = Globals.LogLevel[selected_name]  # Gets the int enum value
+	Globals.log_message("Log level changed to: " + selected_name, Globals.LogLevel.INFO)
+	_save_settings()
+
+# Saves settings to file (call from here or Globals as needed)
+func _save_settings() -> void:
+	var config: ConfigFile = ConfigFile.new()
+	config.set_value("Settings", "log_level", Globals.current_log_level)
+	config.save("user://settings.cfg")  # Web-safe path
+	Globals.log_message("Settings saved.", Globals.LogLevel.DEBUG)
+
+# Handles Back button: Return to main menu
+# In options_menu.gd (_on_back_pressed())
+func _on_back_pressed() -> void:
+	if Globals.previous_scene != "":
+		get_tree().change_scene_to_file(Globals.previous_scene)
+		Globals.log_message("Returning to previous scene: " + Globals.previous_scene, Globals.LogLevel.DEBUG)
+	else:
+		# Fallback to main menu if not set (e.g., direct run)
+		get_tree().change_scene_to_file("res://scenes/main_menu.tscn")
+		Globals.log_message("No previous scene set—falling back to main menu.", Globals.LogLevel.WARNING)

--- a/scripts/options_menu.gd
+++ b/scripts/options_menu.gd
@@ -1,4 +1,4 @@
-extends Control
+extends CanvasLayer
 
 @onready var log_lvl_option: OptionButton = $VBoxContainer/HBoxContainer/LogLevelOptionButton
 @onready var back_button: Button = $VBoxContainer/BackButton
@@ -22,6 +22,9 @@ func _ready() -> void:
 	log_lvl_option.item_selected.connect(_on_log_selected)
 	back_button.pressed.connect(_on_back_pressed)
 
+	# In options_menu.gd (_ready()—add at end)
+	process_mode = Node.PROCESS_MODE_ALWAYS  # Ignores pause for this node/tree
+	Globals.log_message("Set options_menu process_mode to ALWAYS for pause ignoring.", Globals.LogLevel.DEBUG)
 	Globals.log_message("Options menu loaded.", Globals.LogLevel.DEBUG)
 
 
@@ -48,15 +51,3 @@ func _on_back_pressed() -> void:
 	get_tree().paused = false  # Unpause if was paused (safe call)
 	Globals.log_message("Closing options menu.", Globals.LogLevel.DEBUG)
 	queue_free()  # Remove self from tree (returns to underlying scene)
-
-#	if Globals.previous_scene != "":
-#		get_tree().change_scene_to_file(Globals.previous_scene)
-#		Globals.log_message(
-#			"Returning to previous scene: " + Globals.previous_scene, Globals.LogLevel.DEBUG
-#		)
-#	else:
-#		# Fallback to main menu if not set (e.g., direct run)
-#		get_tree().change_scene_to_file("res://scenes/main_menu.tscn")
-#		Globals.log_message(
-#			"No previous scene set—falling back to main menu.", Globals.LogLevel.WARNING
-#		)

--- a/scripts/options_menu.gd
+++ b/scripts/options_menu.gd
@@ -45,14 +45,18 @@ func _save_settings() -> void:
 # Handles Back button: Return to main menu
 # In options_menu.gd (_on_back_pressed())
 func _on_back_pressed() -> void:
-	if Globals.previous_scene != "":
-		get_tree().change_scene_to_file(Globals.previous_scene)
-		Globals.log_message(
-			"Returning to previous scene: " + Globals.previous_scene, Globals.LogLevel.DEBUG
-		)
-	else:
-		# Fallback to main menu if not set (e.g., direct run)
-		get_tree().change_scene_to_file("res://scenes/main_menu.tscn")
-		Globals.log_message(
-			"No previous scene set—falling back to main menu.", Globals.LogLevel.WARNING
-		)
+	get_tree().paused = false  # Unpause if was paused (safe call)
+	Globals.log_message("Closing options menu.", Globals.LogLevel.DEBUG)
+	queue_free()  # Remove self from tree (returns to underlying scene)
+
+#	if Globals.previous_scene != "":
+#		get_tree().change_scene_to_file(Globals.previous_scene)
+#		Globals.log_message(
+#			"Returning to previous scene: " + Globals.previous_scene, Globals.LogLevel.DEBUG
+#		)
+#	else:
+#		# Fallback to main menu if not set (e.g., direct run)
+#		get_tree().change_scene_to_file("res://scenes/main_menu.tscn")
+#		Globals.log_message(
+#			"No previous scene set—falling back to main menu.", Globals.LogLevel.WARNING
+#		)

--- a/scripts/options_menu.gd
+++ b/scripts/options_menu.gd
@@ -3,11 +3,12 @@ extends Control
 @onready var log_lvl_option: OptionButton = $VBoxContainer/HBoxContainer/LogLevelOptionButton
 @onready var back_button: Button = $VBoxContainer/BackButton
 
+
 func _ready() -> void:
 	# Populate OptionButton with all LogLevel enum values
 	for level: String in Globals.LogLevel.keys():
 		log_lvl_option.add_item(level)
-	
+
 	# Set to current log level (find index by enum value)
 	var current_value: int = Globals.current_log_level
 	var index: int = Globals.LogLevel.values().find(current_value)
@@ -16,12 +17,13 @@ func _ready() -> void:
 	else:
 		log_lvl_option.selected = 1  # Fallback to INFO (index 1)
 		Globals.log_message("Invalid saved log level—reset to INFO.", Globals.LogLevel.WARNING)
-	
+
 	# Connect signals
 	log_lvl_option.item_selected.connect(_on_log_selected)
 	back_button.pressed.connect(_on_back_pressed)
-	
+
 	Globals.log_message("Options menu loaded.", Globals.LogLevel.DEBUG)
+
 
 # Handles log level selection change
 # Update _on_log_selected to use the selected name for enum lookup:
@@ -31,6 +33,7 @@ func _on_log_selected(index: int) -> void:
 	Globals.log_message("Log level changed to: " + selected_name, Globals.LogLevel.INFO)
 	_save_settings()
 
+
 # Saves settings to file (call from here or Globals as needed)
 func _save_settings() -> void:
 	var config: ConfigFile = ConfigFile.new()
@@ -38,13 +41,18 @@ func _save_settings() -> void:
 	config.save("user://settings.cfg")  # Web-safe path
 	Globals.log_message("Settings saved.", Globals.LogLevel.DEBUG)
 
+
 # Handles Back button: Return to main menu
 # In options_menu.gd (_on_back_pressed())
 func _on_back_pressed() -> void:
 	if Globals.previous_scene != "":
 		get_tree().change_scene_to_file(Globals.previous_scene)
-		Globals.log_message("Returning to previous scene: " + Globals.previous_scene, Globals.LogLevel.DEBUG)
+		Globals.log_message(
+			"Returning to previous scene: " + Globals.previous_scene, Globals.LogLevel.DEBUG
+		)
 	else:
 		# Fallback to main menu if not set (e.g., direct run)
 		get_tree().change_scene_to_file("res://scenes/main_menu.tscn")
-		Globals.log_message("No previous scene set—falling back to main menu.", Globals.LogLevel.WARNING)
+		Globals.log_message(
+			"No previous scene set—falling back to main menu.", Globals.LogLevel.WARNING
+		)

--- a/scripts/options_menu.gd
+++ b/scripts/options_menu.gd
@@ -43,7 +43,7 @@ var log_level_display_to_enum := {
 # Handles log level selection change
 func _on_log_selected(index: int) -> void:
 	var selected_name: String = log_lvl_option.get_item_text(index)
-	var selected_enum := log_level_display_to_enum.get(selected_name, Globals.LogLevel.INFO)
+	var selected_enum: int = log_level_display_to_enum.get(selected_name, Globals.LogLevel.INFO)
 	Globals.current_log_level = selected_enum
 	Globals.log_message("Log level changed to: " + selected_name, Globals.LogLevel.INFO)
 	_save_settings()

--- a/scripts/options_menu.gd
+++ b/scripts/options_menu.gd
@@ -39,6 +39,7 @@ var log_level_display_to_enum := {
 	"None": Globals.LogLevel.NONE
 }
 
+
 # Handles log level selection change
 func _on_log_selected(index: int) -> void:
 	var selected_name: String = log_lvl_option.get_item_text(index)

--- a/scripts/options_menu.gd
+++ b/scripts/options_menu.gd
@@ -30,11 +30,20 @@ func _ready() -> void:
 	Globals.log_message("Options menu loaded.", Globals.LogLevel.DEBUG)
 
 
+# Explicit mapping from display names to enum values
+var log_level_display_to_enum := {
+	"Debug": Globals.LogLevel.DEBUG,
+	"Info": Globals.LogLevel.INFO,
+	"Warning": Globals.LogLevel.WARNING,
+	"Error": Globals.LogLevel.ERROR,
+	"None": Globals.LogLevel.NONE
+}
+
 # Handles log level selection change
-# Update _on_log_selected to use the selected name for enum lookup:
 func _on_log_selected(index: int) -> void:
 	var selected_name: String = log_lvl_option.get_item_text(index)
-	Globals.current_log_level = Globals.LogLevel[selected_name]  # Gets the int enum value
+	var selected_enum := log_level_display_to_enum.get(selected_name, Globals.LogLevel.INFO)
+	Globals.current_log_level = selected_enum
 	Globals.log_message("Log level changed to: " + selected_name, Globals.LogLevel.INFO)
 	_save_settings()
 

--- a/scripts/options_menu.gd
+++ b/scripts/options_menu.gd
@@ -6,8 +6,11 @@ extends CanvasLayer
 
 func _ready() -> void:
 	# Populate OptionButton with all LogLevel enum values
+	# In _ready() (replace population and add "None")
 	for level: String in Globals.LogLevel.keys():
-		log_lvl_option.add_item(level)
+		if level != "NONE":  # Skip auto-add NONE; add manually as "None"
+			log_lvl_option.add_item(level)  # "Debug", "Info", etc.
+	log_lvl_option.add_item("NONE")  # Manual for title case
 
 	# Set to current log level (find index by enum value)
 	var current_value: int = Globals.current_log_level
@@ -32,20 +35,22 @@ func _ready() -> void:
 
 # Explicit mapping from display names to enum values
 var log_level_display_to_enum := {
-	"Debug": Globals.LogLevel.DEBUG,
-	"Info": Globals.LogLevel.INFO,
-	"Warning": Globals.LogLevel.WARNING,
-	"Error": Globals.LogLevel.ERROR,
-	"None": Globals.LogLevel.NONE
+	"DEBUG": Globals.LogLevel.DEBUG,
+	"INFO": Globals.LogLevel.INFO,
+	"WARNING": Globals.LogLevel.WARNING,
+	"ERROR": Globals.LogLevel.ERROR,
+	"NONE": Globals.LogLevel.NONE
 }
 
 
 # Handles log level selection change
 func _on_log_selected(index: int) -> void:
 	var selected_name: String = log_lvl_option.get_item_text(index)
-	var selected_enum: int = log_level_display_to_enum.get(selected_name, Globals.LogLevel.INFO)
+	var selected_enum: Globals.LogLevel = log_level_display_to_enum.get(
+		selected_name, Globals.LogLevel.INFO
+	)
 	Globals.current_log_level = selected_enum
-	Globals.log_message("Log level changed to: " + selected_name, Globals.LogLevel.INFO)
+	Globals.log_message("Log level changed to: " + selected_name, Globals.LogLevel.INFO)  # May skip if new level high
 	_save_settings()
 
 

--- a/scripts/options_menu.gd
+++ b/scripts/options_menu.gd
@@ -24,7 +24,9 @@ func _ready() -> void:
 
 	# In options_menu.gd (_ready()—add at end)
 	process_mode = Node.PROCESS_MODE_ALWAYS  # Ignores pause for this node/tree
-	Globals.log_message("Set options_menu process_mode to ALWAYS for pause ignoring.", Globals.LogLevel.DEBUG)
+	Globals.log_message(
+		"Set options_menu process_mode to ALWAYS for pause ignoring.", Globals.LogLevel.DEBUG
+	)
 	Globals.log_message("Options menu loaded.", Globals.LogLevel.DEBUG)
 
 

--- a/scripts/pause_menu.gd
+++ b/scripts/pause_menu.gd
@@ -5,7 +5,8 @@ extends CanvasLayer
 
 @onready var resume_button: Button = $VBoxContainer/ResumeButton
 @onready var back_to_main_button: Button = $VBoxContainer/BackToMainButton
-
+@onready var options_button: Button = $VBoxContainer/OptionsButton
+var options_menu: PackedScene = preload("res://scenes/options_menu.tscn")
 
 # Called when the node enters the scene tree.
 # Hides the menu initially.
@@ -48,3 +49,7 @@ func _on_back_to_main_button_pressed() -> void:
 	else:
 		Globals.log_message("Error: Main menu scene not set!", Globals.LogLevel.ERROR)
 		# Optional: Fallback, e.g., get_tree().quit() if critical
+
+
+func _on_options_button_pressed() -> void:
+	Globals.load_options()

--- a/scripts/pause_menu.gd
+++ b/scripts/pause_menu.gd
@@ -8,6 +8,7 @@ extends CanvasLayer
 @onready var options_button: Button = $VBoxContainer/OptionsButton
 var options_menu: PackedScene = preload("res://scenes/options_menu.tscn")
 
+
 # Called when the node enters the scene tree.
 # Hides the menu initially.
 func _ready() -> void:


### PR DESCRIPTION
# Milestone 3: Web Features (add quit handling, export/test HTML5) Part 1

Introduced _notification override in globals.gd to handle window close requests, perform cleanup, and quit the game. Updated index.html and index.pck to reflect new build changes.

## Summary by Sourcery

Introduce web-specific quit handling and options menu with log level persistence, and enhance main menu with fade-in effects and UI restructuring

New Features:
- Handle window close requests with cleanup in globals
- Add options menu with log level settings accessible from main and pause menus
- Implement fade-in animations for main menu UI panels

Enhancements:
- Persist log level settings to user://settings.cfg and load on startup
- Refactor main_menu.gd to consolidate quit dialog setup and adopt panel-based UI
- Update web export index.html to reflect updated index.pck file size