### PR TITLE
Verified Orientation Options

### DIFF
--- a/export/web/index.html
+++ b/export/web/index.html
@@ -111,7 +111,7 @@ body {
 
 		<script src="index.js"></script>
 		<script>
-const GODOT_CONFIG = {"args":[],"canvasResizePolicy":2,"emscriptenPoolSize":8,"ensureCrossOriginIsolationHeaders":true,"executable":"index","experimentalVK":false,"fileSizes":{"index.pck":11404300,"index.wasm":36160334},"focusCanvas":true,"gdextensionLibs":[],"godotPoolSize":4};
+const GODOT_CONFIG = {"args":[],"canvasResizePolicy":2,"emscriptenPoolSize":8,"ensureCrossOriginIsolationHeaders":true,"executable":"index","experimentalVK":false,"fileSizes":{"index.pck":11404604,"index.wasm":36160334},"focusCanvas":true,"gdextensionLibs":[],"godotPoolSize":4};
 const GODOT_THREADS_ENABLED = false;
 const engine = new Engine(GODOT_CONFIG);
 

--- a/project.godot
+++ b/project.godot
@@ -32,7 +32,9 @@ gdscript/warnings/return_value_discarded=1
 
 window/size/viewport_width=1280
 window/size/viewport_height=720
+window/size/resizable=false
 window/stretch/mode="canvas_items"
+window/handheld/orientation=6
 
 [editor_plugins]
 


### PR DESCRIPTION
# Uncaught (in promise) NotSupportedError: screen.orientation.lock() is not available on this device

This is a common quirk when exporting to HTML5, especially since you're testing on Windows 10 (desktop), where browsers like Chrome expose the Web API but throw errors because there's no physical screen to rotate. The game still runs fine, but the console spam from uncaught promises is annoying. We'll fix this with platform-specific logic to avoid calling the lock on unsupported devices, while keeping landscape orientation for mobile where it makes sense for the top-down shooter.

Go to the project settings under Display > Window > Handheld > Orientation. Set to "sensor". This prevents automatic locking on load, which should help avoid the NotSupportedError on desktop HTML5 tests while keeping flexibility for mobile. I'll confirm the options, explain the impact, and update the steps/code accordingly.

## The problem

- Default: 0 (landscape)—this often triggers the lock API on HTML5, causing errors on desktop.
- Impact on HTML5: This setting primarily affects native mobile exports (Android/iOS), but in HTML5, Godot may still attempt JS-based locking if set to a specific value (e.g., landscape), leading to NotSupportedError on non-mobile browsers. Setting to "sensor" (6) disables forced locking, reducing errors while allowing mobile browsers to handle rotation naturally.

## Summary

Disable forced orientation locking in HTML5 exports by changing the default orientation setting to sensor and update the web export template to match the new pck file size.

Bug Fixes:
- Prevent NotSupportedError on desktop browsers by disabling forced orientation lock in HTML5

Enhancements:
- Set default project orientation to sensor (6) to allow natural rotation handling on mobile

Build:
- Update the web export template's fileSizes for index.pck to the new build size