### PR TITLE
Create FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,15 @@
+# These are supported funding model platforms
+
+github: ikostan # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+# patreon: # Replace with a single Patreon username
+# open_collective: # Replace with a single Open Collective username
+# ko_fi: # Replace with a single Ko-fi username
+# tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+# community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+# liberapay: # Replace with a single Liberapay username
+# issuehunt: # Replace with a single IssueHunt username
+# lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+# polar: # Replace with a single Polar username
+# buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
+# thanks_dev: # Replace with a single thanks.dev username
+# custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']


### PR DESCRIPTION
To enable the "Sponsor" button on your repo's main page, linking to your approved GitHub Sponsors profile, replace the template with a minimal configuration focused on GitHub Sponsors. Based on GitHub's documentation on displaying a sponsor button, the file should be in YAML format and placed in the .github folder on the default branch (main). Supported platforms include GitHub Sponsors with syntax like github: USERNAME or an array for multiple (up to 4 sponsored developers for personal accounts). Requirements: Use one username per external platform, and for GitHub, add up to one organization and four developers—no other limits apply here for your solo setup.

## Summary by Sourcery

Add a FUNDING.yml configuration file to enable the GitHub Sponsors button and provide templates for other funding platforms

New Features:
- Add .github/FUNDING.yml to specify GitHub Sponsors username

Enhancements:
- Include commented placeholders for other funding platforms (Patreon, Open Collective, Ko-fi, etc.)