### PR TITLE
Unit Testing: InputRemapButton — Device-Aware Event Handling

### DIFF
--- a/test/gut/test_input_remap_button_device_aware.gd
+++ b/test/gut/test_input_remap_button_device_aware.gd
@@ -156,14 +156,14 @@ func test_irb_04() -> void:
 ## :rtype: void
 func test_irb_05() -> void:
 	button.current_device = InputRemapButton.DeviceType.GAMEPAD
-	const DEADZONE_THRESHOLD: float = 0.5
+	var deadzone_threshold: float = InputRemapButton.AXIS_DEADZONE_THRESHOLD
 	button.button_pressed = true
 	button.pressed.emit()
 	assert_true(button.listening)
 	# Below threshold
 	var low_axis: InputEventJoypadMotion = InputEventJoypadMotion.new()
 	low_axis.axis = JOY_AXIS_LEFT_X
-	low_axis.axis_value = DEADZONE_THRESHOLD - 0.01
+	low_axis.axis_value = deadzone_threshold - 0.01
 	Input.parse_input_event(low_axis)
 	await get_tree().process_frame
 	var events: Array[InputEvent] = InputMap.action_get_events(TEST_ACTION)
@@ -172,7 +172,7 @@ func test_irb_05() -> void:
 	# Beyond threshold
 	var axis: InputEventJoypadMotion = InputEventJoypadMotion.new()
 	axis.axis = JOY_AXIS_LEFT_X
-	axis.axis_value = DEADZONE_THRESHOLD + 0.01
+	axis.axis_value = deadzone_threshold + 0.01
 	Input.parse_input_event(axis)
 	await get_tree().process_frame
 	events = InputMap.action_get_events(TEST_ACTION)


### PR DESCRIPTION
---
name: Default Pull Request Template
about: Suggesting changes to SkyLockAssault
title: ''
labels: ''
assignees: ''
---

## Description

What does this PR do? (e.g., "Fixes player jump physics in level 2" or "Adds
new enemy AI script")

## Related Issue

Closes #ISSUE_NUMBER (if applicable)

## Changes

- [x] List key changes here (e.g., "Updated Jump.gd to use Godot 4.4's new Tween
  system")
- [x] Any breaking changes? (e.g., "Deprecated old signal; migrate to new one")

## Testing

- [x] Ran the game in Godot v4.5 editor—describe what you tested (e.g., "Jump
  works on Win10 with 60 FPS")
- [x] Any new unit tests added? (Link to test scene if yes)
- [x] Screenshots/GIFs if UI-related: (Attach below)

## Checklist

- [x] Code follows Godot style guide (e.g., snake_case for variables)
- [x] No console errors in editor/output
- [x] Ready for review!

## Additional Notes

Anything else? (e.g., "Tested on Win10 64-bit; needs Linux validation")

## Summary by Sourcery

Add unit tests covering device-aware input remapping behavior for InputRemapButton, including display text, remapping, deadzone handling, persistence, and invalid input handling.

Tests:
- Add GUT test suite validating keyboard and gamepad label display, remapping flows, deadzone threshold behavior, and unassigned state for InputRemapButton.
- Add tests ensuring wrong-device and invalid events are ignored without changing mappings or crashing.
- Add persistence tests verifying input mappings are saved to and loaded from config files correctly.
- Add tests covering tab switching between keyboard and gamepad views to ensure correct labels and UI stability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive device-aware input remapping tests covering keyboard and gamepad buttons/axes, deadzone handling, cross-device behavior, unassigned state, persistence (save/load), tab switching stability, wrong-device rejection, and malformed-event resilience (IRB-01 to IRB-10). Per-test setup/teardown ensures input mappings are reset and display text and mapping updates are validated.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->