### PR TITLE
Unit Test : Key Mapping Menu — DeviceSettings & UI Behavior

### DIFF
--- a/scripts/globals.gd
+++ b/scripts/globals.gd
@@ -2,7 +2,11 @@ extends Node
 
 # Global utilities singleton: Provides shared functions like logging.
 # Access from any script as Globals.log_message("message").
+
 enum LogLevel { DEBUG, INFO, WARNING, ERROR, NONE = 4 }
+
+# Shared constants
+const REMAP_PROMPT_TEXT: String = "Press a key or controller button/axis..."
 
 @export var current_log_level: LogLevel = LogLevel.INFO  # Default: Show INFO and above
 @export var enable_debug_logging: bool = false  # Toggle in Inspector or settings
@@ -16,8 +20,6 @@ var options_open: bool = false
 var previous_scene: String = "res://scenes/main_menu.tscn"  # Default fallback
 var options_scene: PackedScene = preload("res://scenes/options_menu.tscn")
 var next_scene: String = ""  # Path to the next scene to load via loading screen.
-# Game version (move @onready here, but use helper)
-# @onready var game_version: String = get_game_version()
 
 
 func _ready() -> void:

--- a/scripts/input_remap_button.gd
+++ b/scripts/input_remap_button.gd
@@ -111,7 +111,7 @@ func _ready() -> void:
 func _on_pressed() -> void:
 	listening = button_pressed
 	if listening:
-		text = "Press a key or controller button/axis..."
+		text = Globals.REMAP_PROMPT_TEXT  # Use the shared constant
 	else:
 		update_button_text()
 

--- a/test/gut/test_key_mapping_menu.gd
+++ b/test/gut/test_key_mapping_menu.gd
@@ -122,7 +122,7 @@ func test_ui_05_label_update_after_remapping() -> void:
 	left_btn.button_pressed = true
 	# Note: Directly calling private methods (_on_pressed, _input) for simulation due to complexity of full input event mocking in GUT unit tests.
 	left_btn._on_pressed()  # Manually trigger the pressed handler to start listening
-	assert_eq(left_btn.text, "Press a key or controller button/axis...")
+	assert_eq(left_btn.text, Globals.REMAP_PROMPT_TEXT)
 	var key_event := InputEventKey.new()
 	key_event.physical_keycode = Key.KEY_A
 	key_event.pressed = true


### PR DESCRIPTION
---
name: Default Pull Request Template
about: Suggesting changes to SkyLockAssault
title: ''
labels: ''
assignees: ''
---

## Description

What does this PR do? (e.g., "Fixes player jump physics in level 2" or "Adds
new enemy AI script")

## Related Issue

Closes #ISSUE_NUMBER (if applicable)

## Changes

- [x] List key changes here (e.g., "Updated Jump.gd to use Godot 4.4's new Tween
  system")
- [x] Any breaking changes? (e.g., "Deprecated old signal; migrate to new one")

## Testing

- [x] Ran the game in Godot v4.5 editor—describe what you tested (e.g., "Jump
  works on Win10 with 60 FPS")
- [x] Any new unit tests added? (Link to test scene if yes)
- [x] Screenshots/GIFs if UI-related: (Attach below)

## Checklist

- [x] Code follows Godot style guide (e.g., snake_case for variables)
- [x] No console errors in editor/output
- [x] Ready for review!

## Additional Notes

Anything else? (e.g., "Tested on Win10 64-bit; needs Linux validation")

## Summary by Sourcery

Add unit tests for the key mapping menu’s device switching, reset behavior, and remap label updates, and centralize the remap prompt text in a global constant.

Enhancements:
- Centralize the key remap prompt text as a shared global constant used by the remap button UI.

Tests:
- Add GUT tests covering keyboard/gamepad switching, per-device reset behavior, and label updates after key and gamepad remapping in the key mapping menu.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added UI tests for the Key Mapping Menu covering device switching (keyboard vs. gamepad), remapping flows, label updates after remapping, and reset actions that restore defaults; tests simulate interactions and verify per-device labels, listening state updates, and consistent behavior across input types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->