### PR TITLE
Merge from main

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ You can play this game on [Itch.io](https://ikostan.itch.io/sky-lock-assault)
    - [Release Drafter](https://github.com/release-drafter/release-drafter?tab=readme-ov-file#readme)
    - [Close Stale Issues and PRs](https://github.com/actions/stale)
    - [AllContributors GitHub App](https://allcontributors.org/docs/en/bot/installation)
-
+9. [Free Web Browser Game Deployment Platforms](files/docs/Platforms_for_Web_Deployment_Guide.md)
 <!-- markdownlint-enable line-length -->
+
 ## Roadmap
 
 Here's a high-level plan for upcoming features. Contributions welcome!

--- a/files/docs/Platforms_for_Web_Deployment_Guide.md
+++ b/files/docs/Platforms_for_Web_Deployment_Guide.md
@@ -1,0 +1,140 @@
+# Free Web Browser Game Deployment Platforms
+
+## Summary of zero-cost publishing platforms for Godot v4.5 HTML5/WebGL games
+
+## Project Context
+
+We're building **SkyLockAssault** — a totally free-to-play browser
+game in **Godot v4.5** on **Windows 10 64-bit**. This is our learning
+journey into game dev, so we're keeping everything practical,
+low-friction, and focused on **automatic deploys** via GitHub Actions
++ CI/CD where possible.
+
+This `.md` file is your living playbook. Update it as you go (e.g. mark
+new platforms as "Deployed: ✅ Yes").
+
+**Target**: Automatic GitHub Actions deploys where possible.
+
+---
+
+## Why Web Platforms for a Free F2P Godot Game?
+
+- **Zero cost to publish** (no Steam $100 fee)
+- **Instant browser play** (Godot WebGL export = one ZIP)
+- **High traffic** for casual games like SkyLockAssault
+- **Ad revenue or donations** without forcing monetization
+- **GitHub Actions** = push → auto-deploy (your dream workflow)
+
+---
+
+## Platform Comparison (Feb 2026)
+
+<!-- markdownlint-disable line-length MD060 -->
+| Platform             | Free Publish | Official Automation      | Playwright Feasible? | Traffic / Reach     | Godot v4.5 Win10 Tip                     | Deployed | Priority for You       |
+|----------------------|--------------|--------------------------|----------------------|---------------------|------------------------------------------|----------|------------------------|
+| **itch.io**          | Yes          | ✅ butler CLI             | Not needed           | Indie + discovery   | Native Godot + godot-ci Actions          | ✅ Yes    | ★★★★★ (Start here)     |
+| **Poki**             | Yes          | ✅ poki-cli               | Not needed           | Massive casual      | Official Godot plugin + CLI in Actions   | ❌ No     | ★★★★★ (High traffic)   |
+| **Viverse**          | Yes          | ✅ VIVERSE CLI            | Not needed           | 3D/WebXR focus      | Godot WebGL + npm CLI (2026 update)      | ❌ No     | ★★★★ (Future-proof)    |
+| **Game Jolt**        | Yes          | ✅ CLI                    | Not needed           | Indie community     | Simple ZIP upload script                 | ❌ No     | ★★★★                   |
+| **iDev.games**       | Yes          | ❌ No                     | ✅ Very easy          | Instant publish     | Simplest form → Playwright target        | ❌ No     | ★★★★ (Bonus)           |
+| **GameMonetize**     | Yes          | ❌ No                     | ✅ Easy               | Ad network          | ZIP drop in dashboard                    | ❌ No     | ★★★★ (Revenue)         |
+| **CrazyGames**       | Yes          | ❌ No                     | ✅ Possible           | Huge casual         | CAPTCHA risk → manual safer              | ❌ No     | ★★★ (Risky)            |
+| **Y8.com**           | Yes          | ❌ No                     | ✅ Possible           | Classic portal      | Basic form                               | ❌ No     | ★★★                    |
+| **GameDistribution** | Yes          | ❌ No                     | ✅ Possible           | B2B distribution    | SDK mandatory first                      | ❌ No     | ★★★                    |
+| **GamePix**          | Yes          | ❌ No                     | ✅ Possible           | Global partners     | Dashboard ZIP                            | ❌ No     | ★★★                    |
+| **Newgrounds**       | Yes          | ❌ No                     | ✅ Partial            | Community           | Manual + API for scores only             | ❌ No     | ★★                     |
+| **SoftGames**        | Yes          | ❌ No                     | ✅ Possible           | Messenger games     | Submit form                              | ❌ No     | ★★ (Low priority)      |
+<!-- markdownlint-enable line-length MD060 -->
+
+---
+
+## Why Most Platforms Refuse Official Automation (Deep Dive)
+
+All "❌ No" platforms require **manual moderation** to fight spam/low-quality
+uploads. Here's the exact reason from their docs/portals (Feb 2026):
+
+<!-- markdownlint-disable line-length -->
+| Platform             | Reason for No Publish API/CLI                                                                                |
+|----------------------|--------------------------------------------------------------------------------------------------------------|
+| **iDev.games**       | API only for in-game data (Game DB / shop). Upload is manual for "instant publish + later verification".     |
+| **CrazyGames**       | Portal is ZIP + form + manual review. SDK only for ads. UI changes often → bots break.                       |
+| **Y8.com**           | Simple upload form → human approval step for quality.                                                        |
+| **GameMonetize**     | You integrate SDK, then manual ZIP in admin dashboard. They handle distribution.                             |
+| **GameDistribution** | SDK mandatory for stats/ads → portal upload only.                                                            |
+| **Newgrounds**       | Project system is manual. In-game API (medals/scores) exists, but upload API is a long-open feature request. |
+| **GamePix**          | Dashboard submit after SDK. No automation.                                                                   |
+| **SoftGames**        | Pure submit form + manual review.                                                                            |
+<!-- markdownlint-enable line-length -->
+
+**Core reason across all**: Manual moderation prevents spam and low-quality content.
+
+**Bottom line:** Moderation = quality control. Playwright can fake the clicks,
+but it's maintenance work.
+
+---
+
+## Automation Strategy
+
+- 100% Auto: itch.io, Poki, Viverse, Game Jolt
+- Playwright Auto: iDev.games, GameMonetize (easiest)
+- Manual + Occasional: CrazyGames, Y8, GameDistribution, GamePix, Newgrounds,
+  SoftGames
+
+---
+
+## Recommended Workflow for SkyLockAssault (Your Learning Path)
+
+### Phase 1: 100% Automatic (Do This First)
+
+1. **itch.io** — Set up butler + GitHub Actions (you already did this ✅)
+2. **Poki** — Add poki-cli (high traffic + official Godot support)
+3. **Viverse** — Add VIVERSE CLI (modern 3D/WebXR bonus)
+
+### Phase 2: Semi-Auto Bonus (Playwright)
+
+- **iDev.games** + **GameMonetize** (easiest forms)
+- Update every 2–4 weeks via one shared script
+
+### Phase 3: Manual Once + Occasional Updates
+
+- CrazyGames, Y8, GameDistribution, GamePix, Newgrounds, SoftGames, Game Jolt
+
+**Goal:** Push to `main` → 10+ platforms updated automatically.
+
+---
+
+## Godot v4.5 Export Tips (Win10)
+
+```bash
+# In your project root (run from PowerShell or Git Bash)
+godot --export "Web" "build/sky-lock-assault"
+cd build/sky-lock-assault
+Compress-Archive -Path * -DestinationPath ../skylockassault.zip
+```
+
+Always include `index.html` at ZIP root.
+
+---
+
+## Automation Setup Quick Starts
+
+### itch.io (Already Done)
+
+Use `butler` + godot-ci GitHub Action.
+
+### Poki (Next)
+
+<!-- markdownlint-disable line-length -->
+```yaml
+# .github/workflows/poki.yml
+- uses: actions/setup-node@v4
+- run: npx @poki/cli upload --game-id YOUR_ID --token ${{ secrets.POKI_TOKEN }} build.zip
+```
+<!-- markdownlint-enable line-length -->
+
+### Viverse (2026 CLI)
+
+```bash
+npm install -g @viverse/cli
+viverse-cli publish --app-id YOUR_APP --file skylockassault.zip
+```

--- a/scenes/key_mapping_menu.tscn
+++ b/scenes/key_mapping_menu.tscn
@@ -11,9 +11,19 @@ corner_radius_top_right = 20
 corner_radius_bottom_right = 20
 corner_radius_bottom_left = 20
 
-[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_5b0ek"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_4k3vu"]
+bg_color = Color(0.6, 0.6, 0.6, 0.39215687)
+corner_radius_top_left = 40
+corner_radius_top_right = 40
+corner_radius_bottom_right = 40
+corner_radius_bottom_left = 40
 
-[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_312xi"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_mxrmg"]
+bg_color = Color(0.6, 0.6, 0.6, 0.39215687)
+corner_radius_top_left = 40
+corner_radius_top_right = 40
+corner_radius_bottom_right = 40
+corner_radius_bottom_left = 40
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_tmees"]
 bg_color = Color(0.2627451, 0.2627451, 0.2627451, 0.5882353)
@@ -36,7 +46,13 @@ corner_radius_bottom_right = 40
 corner_radius_bottom_left = 40
 shadow_size = 5
 
-[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_7mufp"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_rhvir"]
+bg_color = Color(0.53333336, 0.6666667, 0.98039216, 0.3137255)
+corner_radius_top_left = 40
+corner_radius_top_right = 40
+corner_radius_bottom_right = 40
+corner_radius_bottom_left = 40
+shadow_size = 5
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_5b0ek"]
 bg_color = Color(0.2627451, 0.2627451, 0.2627451, 0.5882353)
@@ -60,7 +76,13 @@ corner_radius_bottom_right = 40
 corner_radius_bottom_left = 40
 shadow_size = 5
 
-[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_rhvir"]
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_hh2p6"]
+bg_color = Color(0.53333336, 0.6666667, 0.98039216, 0.3137255)
+corner_radius_top_left = 40
+corner_radius_top_right = 40
+corner_radius_bottom_right = 40
+corner_radius_bottom_left = 40
+shadow_size = 5
 
 [node name="KeyMappingMenu" type="CanvasLayer"]
 script = ExtResource("1_5b0ek")
@@ -71,9 +93,9 @@ anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
-offset_left = -390.0
+offset_left = -450.0
 offset_top = -340.0
-offset_right = 390.0
+offset_right = 450.0
 offset_bottom = 340.0
 grow_horizontal = 2
 grow_vertical = 2
@@ -121,15 +143,15 @@ vertical_alignment = 1
 layout_mode = 2
 size_flags_horizontal = 6
 tooltip_text = "Keyboard"
+focus_neighbor_right = NodePath("../Gamepad")
+focus_neighbor_bottom = NodePath("../../KeyMapContainer/PlayerKeyMap/KeyMappingSpeedUp/SpeedUpInputRemap")
+focus_next = NodePath("../../KeyMapContainer/PlayerKeyMap/KeyMappingSpeedUp/SpeedUpInputRemap")
 theme_override_colors/font_color = Color(0.60784316, 0.60784316, 0.60784316, 1)
-theme_override_colors/font_focus_color = Color(0.60784316, 0.60784316, 0.60784316, 0.92156863)
-theme_override_colors/font_pressed_color = Color(0, 0.8784314, 0.007843138, 1)
-theme_override_colors/font_hover_color = Color(0.60784316, 0.60784316, 0.60784316, 0.92156863)
-theme_override_colors/font_hover_pressed_color = Color(0, 0.8784314, 0.007843138, 0.9019608)
+theme_override_colors/font_pressed_color = Color(0, 0.8784314, 0.007843138, 0.9019608)
 theme_override_colors/font_disabled_color = Color(0.60784316, 0.60784316, 0.60784316, 1)
 theme_override_fonts/font = ExtResource("1_rbr5m")
 theme_override_font_sizes/font_size = 20
-theme_override_styles/focus = SubResource("StyleBoxEmpty_5b0ek")
+theme_override_styles/focus = SubResource("StyleBoxFlat_4k3vu")
 button_pressed = true
 text = "{KEYBOARD}"
 
@@ -137,15 +159,16 @@ text = "{KEYBOARD}"
 layout_mode = 2
 size_flags_horizontal = 8
 tooltip_text = "Gamepad"
+focus_neighbor_left = NodePath("../Keyboard")
+focus_neighbor_bottom = NodePath("../../KeyMapContainer/MenuKeyMap/KeyMappingPause/PauseInputRemap")
+focus_next = NodePath("../../KeyMapContainer/MenuKeyMap/KeyMappingPause/PauseInputRemap")
+focus_previous = NodePath("../Keyboard")
 theme_override_colors/font_color = Color(0.60784316, 0.60784316, 0.60784316, 1)
-theme_override_colors/font_focus_color = Color(0.60784316, 0.60784316, 0.60784316, 0.92156863)
 theme_override_colors/font_pressed_color = Color(0, 0.8784314, 0.007843138, 1)
-theme_override_colors/font_hover_color = Color(0.60784316, 0.60784316, 0.60784316, 0.92156863)
-theme_override_colors/font_hover_pressed_color = Color(0, 0.8784314, 0.007843138, 0.9019608)
 theme_override_colors/font_disabled_color = Color(0.60784316, 0.60784316, 0.60784316, 1)
 theme_override_fonts/font = ExtResource("1_rbr5m")
 theme_override_font_sizes/font_size = 20
-theme_override_styles/focus = SubResource("StyleBoxEmpty_312xi")
+theme_override_styles/focus = SubResource("StyleBoxFlat_mxrmg")
 text = "{GAMEPAD}"
 
 [node name="KeyMapContainer" type="HBoxContainer" parent="Panel/Options"]
@@ -181,6 +204,10 @@ text = "{SPEED=UP:}"
 [node name="SpeedUpInputRemap" type="Button" parent="Panel/Options/KeyMapContainer/PlayerKeyMap/KeyMappingSpeedUp"]
 layout_direction = 3
 layout_mode = 2
+focus_neighbor_top = NodePath("../../../../DeviceTypeContainer/Keyboard")
+focus_neighbor_right = NodePath("../../../MenuKeyMap/KeyMappingPause/PauseInputRemap")
+focus_neighbor_bottom = NodePath("../../KeyMappingSpeedDown/SpeedDownInputRemap")
+focus_next = NodePath("../../KeyMappingSpeedDown/SpeedDownInputRemap")
 theme_override_font_sizes/font_size = 18
 script = ExtResource("2_5b0ek")
 action = "speed_up"
@@ -198,6 +225,11 @@ text = "{SPEED=DOWN:}"
 
 [node name="SpeedDownInputRemap" type="Button" parent="Panel/Options/KeyMapContainer/PlayerKeyMap/KeyMappingSpeedDown"]
 layout_mode = 2
+focus_neighbor_top = NodePath("../../KeyMappingSpeedUp/SpeedUpInputRemap")
+focus_neighbor_right = NodePath("../../../MenuKeyMap/KeyMappingAccept/AcceptInputRemap")
+focus_neighbor_bottom = NodePath("../../KeyMappingLeft/LeftInputRemap")
+focus_next = NodePath("../../KeyMappingLeft/LeftInputRemap")
+focus_previous = NodePath("../../KeyMappingSpeedUp/SpeedUpInputRemap")
 theme_override_font_sizes/font_size = 18
 script = ExtResource("2_5b0ek")
 action = "speed_down"
@@ -215,6 +247,11 @@ text = "{MOVE=LEFT:}"
 
 [node name="LeftInputRemap" type="Button" parent="Panel/Options/KeyMapContainer/PlayerKeyMap/KeyMappingLeft"]
 layout_mode = 2
+focus_neighbor_top = NodePath("../../KeyMappingSpeedDown/SpeedDownInputRemap")
+focus_neighbor_right = NodePath("../../../MenuKeyMap/KeyMappingMenuUp/MenuUpInputRemap")
+focus_neighbor_bottom = NodePath("../../KeyMappingRight/RightInputRemap")
+focus_next = NodePath("../../KeyMappingRight/RightInputRemap")
+focus_previous = NodePath("../../KeyMappingSpeedDown/SpeedDownInputRemap")
 theme_override_font_sizes/font_size = 18
 script = ExtResource("2_5b0ek")
 action = "move_left"
@@ -232,6 +269,11 @@ text = "{MOVE=RIGHT:}"
 
 [node name="RightInputRemap" type="Button" parent="Panel/Options/KeyMapContainer/PlayerKeyMap/KeyMappingRight"]
 layout_mode = 2
+focus_neighbor_top = NodePath("../../KeyMappingLeft/LeftInputRemap")
+focus_neighbor_right = NodePath("../../../MenuKeyMap/KeyMappingMenuDown/MenuDownInputRemap")
+focus_neighbor_bottom = NodePath("../../KeyMappingFire/FireInputRemap")
+focus_next = NodePath("../../KeyMappingFire/FireInputRemap")
+focus_previous = NodePath("../../KeyMappingLeft/LeftInputRemap")
 theme_override_font_sizes/font_size = 18
 script = ExtResource("2_5b0ek")
 action = "move_right"
@@ -249,6 +291,11 @@ text = "{FIRE:}"
 
 [node name="FireInputRemap" type="Button" parent="Panel/Options/KeyMapContainer/PlayerKeyMap/KeyMappingFire"]
 layout_mode = 2
+focus_neighbor_top = NodePath("../../KeyMappingRight/RightInputRemap")
+focus_neighbor_right = NodePath("../../../MenuKeyMap/KeyMappingMenuLeft/MenuLeftInputRemap")
+focus_neighbor_bottom = NodePath("../../KeyMappingNextWeapon/NextWeaponInputRemap")
+focus_next = NodePath("../../KeyMappingNextWeapon/NextWeaponInputRemap")
+focus_previous = NodePath("../../KeyMappingRight/RightInputRemap")
 theme_override_font_sizes/font_size = 18
 script = ExtResource("2_5b0ek")
 action = "fire"
@@ -266,6 +313,11 @@ text = "{NEXT=WEAPON:}"
 
 [node name="NextWeaponInputRemap" type="Button" parent="Panel/Options/KeyMapContainer/PlayerKeyMap/KeyMappingNextWeapon"]
 layout_mode = 2
+focus_neighbor_top = NodePath("../../KeyMappingFire/FireInputRemap")
+focus_neighbor_right = NodePath("../../../MenuKeyMap/KeyMappingMenuRight/MenuRightInputRemap")
+focus_neighbor_bottom = NodePath("../../../../BtnContainer/ControlsBackButton")
+focus_next = NodePath("../../../MenuKeyMap/KeyMappingPause/PauseInputRemap")
+focus_previous = NodePath("../../KeyMappingFire/FireInputRemap")
 theme_override_font_sizes/font_size = 18
 script = ExtResource("2_5b0ek")
 action = "next_weapon"
@@ -297,6 +349,11 @@ text = "{PAUSE:}"
 
 [node name="PauseInputRemap" type="Button" parent="Panel/Options/KeyMapContainer/MenuKeyMap/KeyMappingPause"]
 layout_mode = 2
+focus_neighbor_left = NodePath("../../../PlayerKeyMap/KeyMappingSpeedUp/SpeedUpInputRemap")
+focus_neighbor_top = NodePath("../../../../DeviceTypeContainer/Gamepad")
+focus_neighbor_bottom = NodePath("../../KeyMappingAccept/AcceptInputRemap")
+focus_next = NodePath("../../KeyMappingAccept/AcceptInputRemap")
+focus_previous = NodePath("../../../PlayerKeyMap/KeyMappingNextWeapon/NextWeaponInputRemap")
 theme_override_font_sizes/font_size = 18
 script = ExtResource("2_5b0ek")
 action = "pause"
@@ -314,6 +371,11 @@ text = "{ACCEPT:}"
 
 [node name="AcceptInputRemap" type="Button" parent="Panel/Options/KeyMapContainer/MenuKeyMap/KeyMappingAccept"]
 layout_mode = 2
+focus_neighbor_left = NodePath("../../../PlayerKeyMap/KeyMappingSpeedDown/SpeedDownInputRemap")
+focus_neighbor_top = NodePath("../../KeyMappingPause/PauseInputRemap")
+focus_neighbor_bottom = NodePath("../../KeyMappingMenuUp/MenuUpInputRemap")
+focus_next = NodePath("../../KeyMappingMenuUp/MenuUpInputRemap")
+focus_previous = NodePath("../../KeyMappingPause/PauseInputRemap")
 theme_override_font_sizes/font_size = 18
 script = ExtResource("2_5b0ek")
 action = "ui_accept"
@@ -331,6 +393,11 @@ text = "{MENU=UP:}"
 
 [node name="MenuUpInputRemap" type="Button" parent="Panel/Options/KeyMapContainer/MenuKeyMap/KeyMappingMenuUp"]
 layout_mode = 2
+focus_neighbor_left = NodePath("../../../PlayerKeyMap/KeyMappingLeft/LeftInputRemap")
+focus_neighbor_top = NodePath("../../KeyMappingAccept/AcceptInputRemap")
+focus_neighbor_bottom = NodePath("../../KeyMappingMenuDown/MenuDownInputRemap")
+focus_next = NodePath("../../KeyMappingMenuDown/MenuDownInputRemap")
+focus_previous = NodePath("../../KeyMappingAccept/AcceptInputRemap")
 theme_override_font_sizes/font_size = 18
 script = ExtResource("2_5b0ek")
 action = "ui_up"
@@ -348,6 +415,11 @@ text = "{MENU=DOWN:}"
 
 [node name="MenuDownInputRemap" type="Button" parent="Panel/Options/KeyMapContainer/MenuKeyMap/KeyMappingMenuDown"]
 layout_mode = 2
+focus_neighbor_left = NodePath("../../../PlayerKeyMap/KeyMappingRight/RightInputRemap")
+focus_neighbor_top = NodePath("../../KeyMappingMenuUp/MenuUpInputRemap")
+focus_neighbor_bottom = NodePath("../../KeyMappingMenuLeft/MenuLeftInputRemap")
+focus_next = NodePath("../../KeyMappingMenuLeft/MenuLeftInputRemap")
+focus_previous = NodePath("../../KeyMappingMenuUp/MenuUpInputRemap")
 theme_override_font_sizes/font_size = 18
 script = ExtResource("2_5b0ek")
 action = "ui_down"
@@ -365,6 +437,11 @@ text = "{MENU=LEFT:}"
 
 [node name="MenuLeftInputRemap" type="Button" parent="Panel/Options/KeyMapContainer/MenuKeyMap/KeyMappingMenuLeft"]
 layout_mode = 2
+focus_neighbor_left = NodePath("../../../PlayerKeyMap/KeyMappingFire/FireInputRemap")
+focus_neighbor_top = NodePath("../../KeyMappingMenuDown/MenuDownInputRemap")
+focus_neighbor_bottom = NodePath("../../KeyMappingMenuRight/MenuRightInputRemap")
+focus_next = NodePath("../../KeyMappingMenuRight/MenuRightInputRemap")
+focus_previous = NodePath("../../KeyMappingMenuDown/MenuDownInputRemap")
 theme_override_font_sizes/font_size = 18
 script = ExtResource("2_5b0ek")
 action = "ui_left"
@@ -382,6 +459,11 @@ text = "{MENU=RIGHT:}"
 
 [node name="MenuRightInputRemap" type="Button" parent="Panel/Options/KeyMapContainer/MenuKeyMap/KeyMappingMenuRight"]
 layout_mode = 2
+focus_neighbor_left = NodePath("../../../PlayerKeyMap/KeyMappingNextWeapon/NextWeaponInputRemap")
+focus_neighbor_top = NodePath("../../KeyMappingMenuLeft/MenuLeftInputRemap")
+focus_neighbor_bottom = NodePath("../../../../BtnContainer/ControlResetButton")
+focus_next = NodePath("../../../../BtnContainer/ControlsBackButton")
+focus_previous = NodePath("../../KeyMappingMenuLeft/MenuLeftInputRemap")
 theme_override_font_sizes/font_size = 18
 script = ExtResource("2_5b0ek")
 action = "ui_right"
@@ -396,15 +478,19 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 tooltip_text = "Back button"
+focus_neighbor_top = NodePath("../../KeyMapContainer/PlayerKeyMap/KeyMappingNextWeapon/NextWeaponInputRemap")
+focus_neighbor_right = NodePath("../ControlResetButton")
+focus_next = NodePath("../ControlResetButton")
+focus_previous = NodePath("../../KeyMapContainer/PlayerKeyMap/KeyMappingNextWeapon/NextWeaponInputRemap")
 theme_override_colors/font_color = Color(0.99215686, 0.21568628, 0.2784314, 1)
-theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
+theme_override_colors/font_focus_color = Color(0.9607843, 0.9607843, 0.050980393, 1)
 theme_override_colors/font_hover_color = Color(0.9607843, 0.9607843, 0.050980393, 1)
 theme_override_fonts/font = ExtResource("1_rbr5m")
 theme_override_font_sizes/font_size = 35
 theme_override_styles/normal = SubResource("StyleBoxFlat_tmees")
 theme_override_styles/pressed = SubResource("StyleBoxFlat_ookuy")
 theme_override_styles/hover = SubResource("StyleBoxFlat_kgm0p")
-theme_override_styles/focus = SubResource("StyleBoxEmpty_7mufp")
+theme_override_styles/focus = SubResource("StyleBoxFlat_rhvir")
 text = "{BACK}"
 
 [node name="ControlResetButton" type="Button" parent="Panel/Options/BtnContainer"]
@@ -412,16 +498,20 @@ layout_mode = 2
 size_flags_horizontal = 3
 size_flags_vertical = 3
 tooltip_text = "Reset button"
+focus_neighbor_left = NodePath("../ControlsBackButton")
+focus_neighbor_top = NodePath("../../KeyMapContainer/MenuKeyMap/KeyMappingMenuRight/MenuRightInputRemap")
+focus_neighbor_right = NodePath("../ControlsBackButton")
+focus_next = NodePath("../ControlsBackButton")
+focus_previous = NodePath("../ControlsBackButton")
 theme_override_colors/font_color = Color(0.99215686, 0.21568628, 0.2784314, 1)
-theme_override_colors/font_focus_color = Color(1, 0.19607843, 0.2784314, 0.98039216)
-theme_override_colors/font_pressed_color = Color(0.9607843, 0.9607843, 0.050980393, 0.9019608)
+theme_override_colors/font_focus_color = Color(0.9607843, 0.9607843, 0.050980393, 1)
 theme_override_colors/font_hover_color = Color(0.9607843, 0.9607843, 0.050980393, 1)
 theme_override_fonts/font = ExtResource("1_rbr5m")
 theme_override_font_sizes/font_size = 35
 theme_override_styles/normal = SubResource("StyleBoxFlat_5b0ek")
 theme_override_styles/pressed = SubResource("StyleBoxFlat_7mufp")
 theme_override_styles/hover = SubResource("StyleBoxFlat_0yqio")
-theme_override_styles/focus = SubResource("StyleBoxEmpty_rhvir")
+theme_override_styles/focus = SubResource("StyleBoxFlat_hh2p6")
 text = "{RESET}"
 
 [connection signal="toggled" from="Panel/Options/DeviceTypeContainer/Keyboard" to="." method="_on_keyboard_toggled"]

--- a/scenes/main_scene.tscn
+++ b/scenes/main_scene.tscn
@@ -236,3 +236,26 @@ region_rect = Rect2(128, 128, 128, 128)
 [node name="Sprite2D" type="Sprite2D" parent="Background/Bushes"]
 texture_filter = 1
 texture = ExtResource("5_rt2n2")
+
+[node name="HUD" type="CanvasLayer" parent="."]
+
+[node name="MessageLabel" type="Label" parent="HUD"]
+top_level = true
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -20.0
+offset_top = -11.5
+offset_right = 20.0
+offset_bottom = 11.5
+grow_horizontal = 2
+grow_vertical = 2
+size_flags_horizontal = 6
+size_flags_vertical = 6
+theme_override_colors/font_color = Color(0.99215686, 0.21568628, 0.2784314, 0.5882353)
+theme_override_fonts/font = ExtResource("2_pu3yx")
+theme_override_font_sizes/font_size = 35
+horizontal_alignment = 1
+vertical_alignment = 1

--- a/scenes/pause_menu.tscn
+++ b/scenes/pause_menu.tscn
@@ -62,6 +62,7 @@ process_mode = 3
 script = ExtResource("1_n87rw")
 
 [node name="Panel" type="Panel" parent="."]
+top_level = true
 anchors_preset = 8
 anchor_left = 0.5
 anchor_top = 0.5

--- a/scripts/options_menu.gd
+++ b/scripts/options_menu.gd
@@ -126,6 +126,22 @@ func _ready() -> void:
 	_grab_first_button_focus()  # Dynamically grab focus on the first button
 
 
+## Called when returning from the Key Mapping menu.
+## Focuses the Key Mapping button using the same safe helper as everywhere else.
+func grab_focus_on_key_mapping_button() -> void:
+	Globals.ensure_initial_focus(
+		key_mapping_button,
+		[
+			advanced_settings_button,
+			audio_settings_button,
+			key_mapping_button,
+			gameplay_settings_button,
+			options_back_button
+		],
+		"Options Menu (returned from Key Mapping)"
+	)
+
+
 func _grab_first_button_focus() -> void:
 	## Finds the first visible/enabled Button in the container and hands it
 	## to the centralized focus helper. The helper will decide whether to

--- a/test/gut/test_combined_multi_manager_loads.gd
+++ b/test/gut/test_combined_multi_manager_loads.gd
@@ -3,8 +3,7 @@
 ## test_combined_multi_manager_loads.gd
 ## GUT unit tests for combined/multi-manager config loads/saves.
 ## Covers TC-SL-11 to TC-SL-15 from test plan.
-## Test Plan:
-## https://github.com/ikostan/SkyLockAssault/issues/295
+## Test Plan: https://github.com/ikostan/SkyLockAssault/issues/295
 
 extends "res://addons/gut/test.gd"
 
@@ -45,17 +44,18 @@ func before_each() -> void:
 		var ev: InputEventKey = InputEventKey.new()
 		ev.physical_keycode = default_key
 		InputMap.action_add_event(action, ev)
-	Settings._needs_migration = false  # Reset migration flag
+	Settings._needs_save = false  # Reset migration flag
 
 
 ## TC-SL-11 | Config with all sections (non-default audio, inputs, settings). | Call AudioManager.load_volumes(); Then Settings.load_input_mappings(); Then Globals._load_settings() | Each loads their section without affecting others; AudioManager gets "audio"; Settings gets "input"; Globals gets "Settings"; All apply correctly; No cross-overwrites.
+## Updated for per-device unbound: partial input ["key:87"] loads keyboard only (gamepad unbound).
 ## :rtype: void
 func test_tc_sl_11() -> void:
 	var config: ConfigFile = ConfigFile.new()
 	# Audio
 	config.set_value("audio", "master_volume", 0.5)
 	config.set_value("audio", "master_muted", true)
-	# Inputs
+	# Inputs: Partial (keyboard only) - tests new per-device unbound (no auto-gamepad)
 	config.set_value("input", "speed_up", ["key:87"])
 	# Settings
 	config.set_value("Settings", "log_level", Globals.LogLevel.WARNING)
@@ -68,15 +68,11 @@ func test_tc_sl_11() -> void:
 	# Verify Audio
 	assert_almost_eq(AudioManager.master_volume, 0.5, 0.01)
 	assert_true(AudioManager.master_muted)
-	# Verify Inputs (e.g., speed_up is KEY_W=87, plus added default gamepad)
-	var events: Array = InputMap.action_get_events("speed_up")
-	assert_eq(events.size(), 2)
+	# Verify Inputs: Only saved key (no gamepad - per-device unbound)
+	var events: Array[InputEvent] = InputMap.action_get_events("speed_up")
+	assert_eq(events.size(), 1)
 	assert_true(events[0] is InputEventKey)
 	assert_eq(events[0].physical_keycode, 87)
-	assert_true(events[1] is InputEventJoypadMotion)
-	assert_eq(events[1].axis, JOY_AXIS_TRIGGER_RIGHT)
-	assert_eq(events[1].axis_value, 1.0)
-	assert_eq(events[1].device, -1)
 	# Verify Globals
 	assert_eq(Globals.current_log_level, Globals.LogLevel.WARNING)
 	assert_eq(Globals.difficulty, 1.5)
@@ -111,18 +107,18 @@ func test_tc_sl_12() -> void:
 	assert_eq(loaded_config.get_value("Settings", "log_level"), "invalid")
 
 
-## TC-SL-13 | Config with old-format inputs (int keycodes); No audio. | Call Settings.load_input_mappings() (sets _needs_migration=true, saves upgraded); Then AudioManager.save_volumes() | Inputs upgraded and saved; Then audio added without re-overwriting inputs; Config has upgraded "input" and new "audio".
+## TC-SL-13 | Config with old-format inputs (int keycodes); No audio. | Call Settings.load_input_mappings() (sets _needs_save=true, saves upgraded); Then AudioManager.save_volumes() | Inputs upgraded and saved; Then audio added without re-overwriting inputs; Config has upgraded "input" and new "audio".
 ## :rtype: void
 func test_tc_sl_13() -> void:
 	var config: ConfigFile = ConfigFile.new()
 	config.set_value("input", "speed_up", 87)  # Old int format
 	config.save(test_config_path)
-	# Load inputs (should set _needs_migration)
+	# Load inputs (should set _needs_save)
 	Settings.load_input_mappings(test_config_path)
 	# Manually save if migration needed (since _ready() not re-called in test)
-	if Settings._needs_migration:
+	if Settings._needs_save:
 		Settings.save_input_mappings(test_config_path)
-		Settings._needs_migration = false
+		Settings._needs_save = false
 	# Verify migrated in InputMap
 	var events: Array = InputMap.action_get_events("speed_up")
 	assert_eq(events.size(), 2)

--- a/test/gut/test_error_edge_cases.gd
+++ b/test/gut/test_error_edge_cases.gd
@@ -40,7 +40,7 @@ func before_each() -> void:
 		AudioServer.add_bus()
 		AudioServer.set_bus_name(AudioServer.get_bus_count() - 1, AudioConstants.BUS_SFX_ROTORS)
 	# Reset migration flag
-	Settings._needs_migration = false
+	Settings._needs_save = false
 
 
 ## TC-SL-21 | Config path invalid/unwritable (simulate via temp path or mock). | Call AudioManager.save_volumes() | Error logged (e.g., "Failed to save config"); No crash; AudioManager unchanged.
@@ -100,9 +100,9 @@ func test_tc_sl_25() -> void:
 	# Load inputs (migrate)
 	Settings.load_input_mappings(test_config_path)
 	# Manually save if migration (since no _ready in test)
-	if Settings._needs_migration:
+	if Settings._needs_save:
 		Settings.save_input_mappings(test_config_path)
-		Settings._needs_migration = false
+		Settings._needs_save = false
 	# Verify upgraded
 	config = ConfigFile.new()
 	config.load(test_config_path)
@@ -116,4 +116,4 @@ func test_tc_sl_25() -> void:
 	assert_eq(config.get_value("input", "speed_up"), ["key:87", "joyaxis:5:1.0:-1"])
 	assert_eq(config.get_value("audio", "master_volume"), 0.5)
 	# No re-migration
-	assert_false(Settings._needs_migration)
+	assert_false(Settings._needs_save)

--- a/test/gut/test_get_pause_binding_label_for_device.gd
+++ b/test/gut/test_get_pause_binding_label_for_device.gd
@@ -1,0 +1,83 @@
+## test_get_pause_binding_label_for_device.gd
+## Regression tests for:
+## Settings.get_pause_binding_label_for_device()
+
+extends GutTest
+
+var settings: Node
+
+func before_each() -> void:
+	settings = preload("res://scripts/settings.gd").new()
+	add_child_autofree(settings)
+
+	# Ensure clean input state
+	InputMap.erase_action("pause")
+	InputMap.add_action("pause")
+
+func after_each() -> void:
+	await get_tree().process_frame
+
+# ============================================================
+# KEYBOARD TESTS
+# ============================================================
+
+func test_pause_label_returns_keyboard_key_name() -> void:
+	var event := InputEventKey.new()
+	event.physical_keycode = KEY_ESCAPE
+	event.keycode = KEY_ESCAPE
+	event.device = -1
+	InputMap.action_add_event("pause", event)
+	var label: String = settings.get_pause_binding_label_for_device("keyboard")
+	assert_true(label is String)
+	assert_true(label.length() > 0)
+
+
+func test_pause_label_returns_unbound_when_keyboard_not_bound() -> void:
+	var label: String = settings.get_pause_binding_label_for_device("keyboard")
+	print("label: " + label)
+	assert_true(label == "UNBOUND")
+
+
+# ============================================================
+# JOYPAD (gamepad) TESTS
+# ============================================================
+
+func test_pause_label_returns_gamepad_button_name() -> void:
+	var event := InputEventJoypadButton.new()
+	event.button_index = JOY_BUTTON_START
+	event.device = 0
+	InputMap.action_add_event("pause", event)
+	var label: String = settings.get_pause_binding_label_for_device("gamepad")
+	assert_true(label is String)
+	assert_true(label.length() > 0)
+
+
+func test_pause_label_falls_back_when_no_matching_device() -> void:
+	var key_event := InputEventKey.new()
+	key_event.physical_keycode = KEY_ESCAPE
+	key_event.keycode = KEY_ESCAPE
+	key_event.device = -1
+	InputMap.action_add_event("pause", key_event)
+	var label: String = settings.get_pause_binding_label_for_device("gamepad")
+	assert_true(label is String)
+	assert_true(label.length() > 0)
+	print("label: " + label)
+	assert_eq(label.strip_edges(), "ESCAPE")
+
+
+
+func test_pause_label_ignores_other_gamepad_devices() -> void:
+	var event := InputEventJoypadButton.new()
+	event.button_index = JOY_BUTTON_START
+	event.device = 1
+	InputMap.action_add_event("pause", event)
+	# If your implementation filters by device id internally,
+	# this ensures it does not accidentally match wrong device.
+	var label: String = settings.get_pause_binding_label_for_device("gamepad")
+	# Depending on your logic, adjust if needed
+	assert_true(label == "" or label.length() > 0)
+
+
+func test_pause_label_returns_unbound_when_no_events() -> void:
+	var label: String = settings.get_pause_binding_label_for_device("keyboard")
+	assert_eq(label, "UNBOUND")

--- a/test/gut/test_input_remap_ec.gd
+++ b/test/gut/test_input_remap_ec.gd
@@ -43,7 +43,8 @@ func after_each() -> void:
 	await get_tree().process_frame
 
 
-## EC-02 | No device events | Remap triggered without input | Do nothing | UI unchanged
+# EC-02 | No device events | Remap triggered without input | Do nothing | UI unchanged
+# :rtype: void
 func test_ec_02_remap_cancelled_no_input() -> void:
 	var prior_ev := InputEventKey.new()
 	prior_ev.physical_keycode = KEY_A
@@ -51,11 +52,10 @@ func test_ec_02_remap_cancelled_no_input() -> void:
 	var prior_text := button.get_event_label(prior_ev)
 
 	button.button_pressed = true
-	button.pressed.emit()                 # start listening
+	button.pressed.emit()
 	assert_true(button.listening)
-	assert_eq(button.text, Globals.REMAP_PROMPT_TEXT)
+	assert_eq(button.text, Globals.REMAP_PROMPT_KEYBOARD)  # updated
 
-	# Cancel by toggling button again (no input event)
 	button.button_pressed = false
 	button.pressed.emit()
 

--- a/test/test_settings.gd
+++ b/test/test_settings.gd
@@ -311,13 +311,13 @@ func test_migration_save_only_on_old() -> void:
 	Settings.load_input_mappings(test_path, ["test_action"])
 	
 	# Simulate _ready() save logic—check if flag triggers save
-	assert_bool(Settings._needs_migration).is_true()  # Flag set
+	assert_bool(Settings._needs_save).is_true()  # Flag set
 	Settings.save_input_mappings(test_path, ["test_action"])  # Would save in new format
 	
 	# Reload to verify upgraded, no flag next time
-	Settings._needs_migration = false  # Reset
+	Settings._needs_save = false  # Reset
 	Settings.load_input_mappings(test_path, ["test_action"])
-	assert_bool(Settings._needs_migration).is_false()  # No old format now
+	assert_bool(Settings._needs_save).is_false()  # No old format now
 
 # Test no save on new-format or no config
 func test_no_migration_on_new() -> void:
@@ -329,7 +329,7 @@ func test_no_migration_on_new() -> void:
 	config.save(test_path)
 	
 	Settings.load_input_mappings(test_path, ["test_action"])
-	assert_bool(Settings._needs_migration).is_false()  # No flag
+	assert_bool(Settings._needs_save).is_false()  # No flag
 
 
 # Test type-safe load for new-format array


### PR DESCRIPTION
---
name: Default Pull Request Template
about: Suggesting changes to SkyLockAssault
title: ''
labels: ''
assignees: ''
---

## Description

What does this PR do? (e.g., "Fixes player jump physics in level 2" or "Adds
new enemy AI script")

## Related Issue

Closes #ISSUE_NUMBER (if applicable)

## Changes

- [ ] List key changes here (e.g., "Updated Jump.gd to use Godot 4.4's new Tween
  system")
- [ ] Any breaking changes? (e.g., "Deprecated old signal; migrate to new one")

## Testing

- [ ] Ran the game in Godot v4.5 editor—describe what you tested (e.g., "Jump
  works on Win10 with 60 FPS")
- [ ] Any new unit tests added? (Link to test scene if yes)
- [ ] Screenshots/GIFs if UI-related: (Attach below)

## Checklist

- [ ] Code follows Godot style guide (e.g., snake_case for variables)
- [ ] No console errors in editor/output
- [ ] Ready for review!

## Additional Notes

Anything else? (e.g., "Tested on Win10 64-bit; needs Linux validation")

## Summary by Sourcery

Improve input mapping robustness, conflict handling, and UI feedback for unbound controls while adding platform docs and strengthening tests.

New Features:
- Add conflict-aware input remapping with a confirmation dialog that selectively unbinds conflicting actions per device.
- Persist and restore the last selected input device and expose device-specific pause binding labels for UI messaging.
- Introduce HUD and main-menu warnings for unbound critical controls, with links into the key mapping menu.
- Add human-readable labels for keyboard and gamepad inputs, used throughout key mapping UI.

Bug Fixes:
- Preserve explicitly unbound actions across reloads, preventing default bindings from being reapplied after conflicts.
- Handle corrupted or legacy input config data safely, falling back to defaults without crashing or losing unrelated sections.
- Fix background loading progress behavior and minimum load time quirks, especially on web builds.
- Ensure focus is restored correctly when leaving key mapping/options menus and when returning to the main menu.
- Correct default gamepad mappings and reset behavior to avoid duplicate or stale bindings.

Enhancements:
- Refactor settings input migration into a generic save flag and shared default-backfill helper, including one-time legacy migrations for critical actions.
- Make key mapping prompts device-specific and centralize focus management helpers in Globals for consistent controller navigation.
- Extend Globals with helpers to load key mapping in-place and track the current input device for messaging.
- Tighten tests around combined config loading, key mapping UI, input remapping, and edge cases for device-aware behavior.
- Improve loading screen script structure and comments for clarity and platform-specific tuning.

Documentation:
- Add a deployment guide documenting free web browser platforms and automation options for publishing the Godot web build.
- Update README roadmap section with a link to the new web deployment platforms guide.

Tests:
- Add extensive regression and edge-case tests for settings migration, unbound persistence, pause binding labels, key mapping UI behavior, input remap buttons, and combined config flows, including new EC and KM cases.
- Introduce dedicated tests for device-specific pause labels and for keyboard/gamepad labeling, as well as unbound control warnings and device validation.