### PR TITLE
Avoid preloading scenes to break circular deps

### DIFF
--- a/config_resources/default_settings.tres
+++ b/config_resources/default_settings.tres
@@ -6,4 +6,6 @@
 
 [resource]
 script = ExtResource("3_qb8m4")
+key_mapping_scene = ExtResource("1_qho2n")
+options_scene = ExtResource("2_b4w4u")
 metadata/_custom_type_script = "uid://cgtk0ximoo5ty"

--- a/scripts/game_settings_resource.gd
+++ b/scripts/game_settings_resource.gd
@@ -52,8 +52,10 @@ signal setting_changed(setting_name: String, new_value: Variant)
 @export_group("UI & Scenes")
 @export var remap_prompt_keyboard: String = "Press a key..."
 @export var remap_prompt_gamepad: String = "Press a gamepad button/axis..."
-@export var key_mapping_scene: PackedScene = preload("res://scenes/key_mapping_menu.tscn")
-@export var options_scene: PackedScene = preload("res://scenes/options_menu.tscn")
+
+# Use type-hinting without forced preloading to break circular dependencies
+@export var key_mapping_scene: PackedScene
+@export var options_scene: PackedScene
 
 # Private member variables moved to bottom to satisfy class-definitions-order
 var _current_log_level: int = 1

--- a/scripts/game_settings_resource.gd
+++ b/scripts/game_settings_resource.gd
@@ -61,3 +61,11 @@ signal setting_changed(setting_name: String, new_value: Variant)
 var _current_log_level: int = 1
 var _difficulty: float = 1.0
 var _enable_debug_logging: bool = false
+
+
+func _init() -> void:
+	# This only runs if the values aren't already set (like in a .new() call)
+	if not key_mapping_scene:
+		key_mapping_scene = load("res://scenes/key_mapping_menu.tscn")
+	if not options_scene:
+		options_scene = load("res://scenes/options_menu.tscn")

--- a/test/gut/test_globals_resource.gd
+++ b/test/gut/test_globals_resource.gd
@@ -24,11 +24,9 @@ func after_each() -> void:
 func test_logging_default_level() -> void:
 	gut.p("Testing: Log level should default to INFO (1).")
 	
-	# Instead of forcing the value, we re-initialize the Resource to its default state.
-	# This ensures we are testing the actual default defined in your Resource script.
-	Globals.settings = GameSettingsResource.new() 
+	# FIX: Load the actual resource file instead of creating a blank .new()
+	Globals.settings = load("res://config_resources/default_settings.tres") 
 	
-	# Accessing settings via the new Resource reference
 	assert_eq(Globals.settings.current_log_level, 1, "Default log level must be INFO (1)")
 
 


### PR DESCRIPTION
Stop forcing preload of key_mapping_scene and options_scene in GameSettingsResource; export them as PackedScene properties instead so they can be assigned via resources/editor and avoid circular dependencies. Update default_settings.tres to include ExtResource entries for the two scenes. No behavioral changes besides how scenes are referenced/loaded.

---
name: Default Pull Request Template
about: Suggesting changes to SkyLockAssault
title: ''
labels: ''
assignees: ''
---

## Description

What does this PR do? (e.g., "Fixes player jump physics in level 2" or "Adds
new enemy AI script")

## Related Issue

Closes #ISSUE_NUMBER (if applicable)

## Changes

- [ ] List key changes here (e.g., "Updated Jump.gd to use Godot 4.4's new Tween
  system")
- [ ] Any breaking changes? (e.g., "Deprecated old signal; migrate to new one")

## Testing

- [ ] Ran the game in Godot v4.5 editor—describe what you tested (e.g., "Jump
  works on Win10 with 60 FPS")
- [ ] Any new unit tests added? (Link to test scene if yes)
- [ ] Screenshots/GIFs if UI-related: (Attach below)

## Checklist

- [ ] Code follows Godot style guide (e.g., snake_case for variables)
- [ ] No console errors in editor/output
- [ ] Ready for review!

## Additional Notes

Anything else? (e.g., "Tested on Win10 64-bit; needs Linux validation")

## Summary by Sourcery

Enhancements:
- Expose key mapping and options menu scenes as assignable PackedScene exports in the game settings resource instead of hard-coded preloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized scene resource loading and initialization patterns to improve application startup performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->