### PR TITLE
Bump urllib3 from 2.6.3 to 2.7.0 in the pip group across 1 directory

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,4 +31,4 @@ setuptools==80.10.2
 six==1.17.0
 text-unidecode==1.3
 typing_extensions==4.15.0
-urllib3==2.6.3
+urllib3==2.7.0


### PR DESCRIPTION
Bumps the pip group with 1 update in the / directory: [urllib3](https://github.com/urllib3/urllib3).


Updates `urllib3` from 2.6.3 to 2.7.0
- [Release notes](https://github.com/urllib3/urllib3/releases)
- [Changelog](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst)
- [Commits](https://github.com/urllib3/urllib3/compare/2.6.3...2.7.0)

---
updated-dependencies:
- dependency-name: urllib3 dependency-version: 2.7.0 dependency-type: direct:production dependency-group: pip ...

---
name: Default Pull Request Template
about: Suggesting changes to SkyLockAssault
title: ''
labels: ''
assignees: ''
---

## Description

What does this PR do? (e.g., "Fixes player jump physics in level 2" or "Adds
new enemy AI script")

## Related Issue

Closes #ISSUE_NUMBER (if applicable)

## Changes

- [ ] List key changes here (e.g., "Updated Jump.gd to use Godot 4.4's new Tween
  system")
- [ ] Any breaking changes? (e.g., "Deprecated old signal; migrate to new one")

## Testing

- [ ] Ran the game in Godot v4.5 editor—describe what you tested (e.g., "Jump
  works on Win10 with 60 FPS")
- [ ] Any new unit tests added? (Link to test scene if yes)
- [ ] Screenshots/GIFs if UI-related: (Attach below)

## Checklist

- [ ] Code follows Godot style guide (e.g., snake_case for variables)
- [ ] No console errors in editor/output
- [ ] Ready for review!

## Additional Notes

Anything else? (e.g., "Tested on Win10 64-bit; needs Linux validation")
