### PR TITLE
Cicd deployment workflow fails with 404 on godot checksum download

### DIFF
--- a/.github/workflows/deploy_to_itch.yml
+++ b/.github/workflows/deploy_to_itch.yml
@@ -67,7 +67,7 @@ jobs:
 
           EXE_URL="https://github.com/godotengine/godot/releases/download/4.6.3-stable/Godot_v4.6.3-stable_linux.x86_64.zip"
           TEMPLATE_URL="https://github.com/godotengine/godot/releases/download/4.6.3-stable/Godot_v4.6.3-stable_export_templates.tpz"
-          CHECKSUM_URL="https://github.com/godotengine/godot/releases/download/4.6.3-stable/Godot_v4.6.3-stable_SHA256SUMS.txt"
+          CHECKSUM_URL="https://github.com/godotengine/godot/releases/download/4.6.3-stable/SHA256SUMS.txt"
 
           echo "📥 Downloading Godot executable..."
           curl -fL --show-error -o Godot_v4.6.3-stable_linux.x86_64.zip "$EXE_URL"

--- a/.github/workflows/deploy_to_itch.yml
+++ b/.github/workflows/deploy_to_itch.yml
@@ -19,6 +19,7 @@ on:  # yamllint disable-line rule:truthy
 env:
   BUTLER_VERSION: "15.27.0"
   BUTLER_SHA256: "b9f0d6eef33036031cafaf59939d9f3bc724e2b674c510d4a9cf8a9f1008e299"
+  GODOT_VERSION: "4.6.3-stable"
 
 jobs:
   export-and-deploy:
@@ -65,15 +66,15 @@ jobs:
           mkdir -p godot_binaries
           cd godot_binaries
 
-          EXE_URL="https://github.com/godotengine/godot/releases/download/4.6.3-stable/Godot_v4.6.3-stable_linux.x86_64.zip"
-          TEMPLATE_URL="https://github.com/godotengine/godot/releases/download/4.6.3-stable/Godot_v4.6.3-stable_export_templates.tpz"
-          CHECKSUM_URL="https://github.com/godotengine/godot/releases/download/4.6.3-stable/SHA256SUMS.txt"
+          EXE_URL="https://github.com/godotengine/godot/releases/download/${{ env.GODOT_VERSION }}/Godot_v${{ env.GODOT_VERSION }}_linux.x86_64.zip"
+          TEMPLATE_URL="https://github.com/godotengine/godot/releases/download/${{ env.GODOT_VERSION }}/Godot_v${{ env.GODOT_VERSION }}_export_templates.tpz"
+          CHECKSUM_URL="https://github.com/godotengine/godot/releases/download/${{ env.GODOT_VERSION }}/SHA256SUMS.txt"
 
           echo "📥 Downloading Godot executable..."
-          curl -fL --show-error -o Godot_v4.6.3-stable_linux.x86_64.zip "$EXE_URL"
+          curl -fL --show-error -o "Godot_v${{ env.GODOT_VERSION }}_linux.x86_64.zip" "$EXE_URL"
 
           echo "📥 Downloading Godot export templates..."
-          curl -fL --show-error -o Godot_v4.6.3-stable_export_templates.tpz "$TEMPLATE_URL"
+          curl -fL --show-error -o "Godot_v${{ env.GODOT_VERSION }}_export_templates.tpz" "$TEMPLATE_URL"
 
           echo "📥 Downloading official SHA-256 checksums..."
           curl -fL --show-error -o SHA256SUMS.txt "$CHECKSUM_URL"
@@ -101,8 +102,8 @@ jobs:
         id: "export"
         uses: "firebelley/godot-export@615a6f7afc22d6266bf55c17748fb07447e8bdab"
         with:
-          godot_executable_download_url: "http://localhost:8000/Godot_v4.6.3-stable_linux.x86_64.zip"
-          godot_export_templates_download_url: "http://localhost:8000/Godot_v4.6.3-stable_export_templates.tpz"
+          godot_executable_download_url: "http://localhost:8000/Godot_v${{ env.GODOT_VERSION }}_linux.x86_64.zip"
+          godot_export_templates_download_url: "http://localhost:8000/Godot_v${{ env.GODOT_VERSION }}_export_templates.tpz"
           relative_project_path: "./"
           relative_export_path: "./export/web"
           archive_output: true

--- a/project.godot
+++ b/project.godot
@@ -55,7 +55,7 @@ window/vsync/vsync_mode=0
 
 [editor_plugins]
 
-enabled=PackedStringArray("res://addons/gdUnit4/plugin.cfg", "res://addons/gut/plugin.cfg")
+enabled=PackedStringArray("res://addons/gut/plugin.cfg")
 
 [game]
 


### PR DESCRIPTION
---
name: Default Pull Request Template
about: Suggesting changes to SkyLockAssault
title: ''
labels: ''
assignees: ''
---

## Description

What does this PR do? (e.g., "Fixes player jump physics in level 2" or "Adds
new enemy AI script")

## Related Issue

Closes #ISSUE_NUMBER (if applicable)

## Changes

- [ ] List key changes here (e.g., "Updated Jump.gd to use Godot 4.4's new Tween
  system")
- [ ] Any breaking changes? (e.g., "Deprecated old signal; migrate to new one")

## Testing

- [ ] Ran the game in Godot v4.5 editor—describe what you tested (e.g., "Jump
  works on Win10 with 60 FPS")
- [ ] Any new unit tests added? (Link to test scene if yes)
- [ ] Screenshots/GIFs if UI-related: (Attach below)

## Checklist

- [ ] Code follows Godot style guide (e.g., snake_case for variables)
- [ ] No console errors in editor/output
- [ ] Ready for review!

## Additional Notes

Anything else? (e.g., "Tested on Win10 64-bit; needs Linux validation")

## Summary by Sourcery

CI:
- Update the checksum file URL in the GitHub deployment workflow to point to the correct Godot 4.6.3 SHA256SUMS resource.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment verification process to use consolidated checksum configuration for improved release integrity
  * Streamlined development environment tooling setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->