### PR TITLE
Add Godot version to itch deploy

### DIFF
--- a/.github/workflows/lint_test_deploy.yml
+++ b/.github/workflows/lint_test_deploy.yml
@@ -97,6 +97,7 @@ jobs:
     uses: "./.github/workflows/deploy_to_itch.yml"
     with:
       version: ${{ needs.release_drafter.outputs.release_tag }}
+      godot_version: "4.6.3-stable"
     secrets:
       ITCHIO_API_KEY: "${{ secrets.ITCHIO_API_KEY }}"
       PRODUCTION_SALT: "${{ secrets.PRODUCTION_SALT }}"


### PR DESCRIPTION
Set godot_version to "4.6.3-stable" for the deploy_to_itch step in .github/workflows/lint_test_deploy.yml so the itch deployment uses the specified Godot runtime (ensures consistent build/runtime environment).

---
name: Default Pull Request Template
about: Suggesting changes to SkyLockAssault
title: ''
labels: ''
assignees: ''
---

## Description

What does this PR do? (e.g., "Fixes player jump physics in level 2" or "Adds
new enemy AI script")

## Related Issue

Closes #ISSUE_NUMBER (if applicable)

## Changes

- [x] List key changes here (e.g., "Updated Jump.gd to use Godot 4.4's new Tween
  system")
- [x] Any breaking changes? (e.g., "Deprecated old signal; migrate to new one")

## Testing

- [x] Ran the game in Godot v4.5 editor—describe what you tested (e.g., "Jump
  works on Win10 with 60 FPS")
- [x] Any new unit tests added? (Link to test scene if yes)
- [x] Screenshots/GIFs if UI-related: (Attach below)

## Checklist

- [x] Code follows Godot style guide (e.g., snake_case for variables)
- [x] No console errors in editor/output
- [x] Ready for review!

## Additional Notes

Anything else? (e.g., "Tested on Win10 64-bit; needs Linux validation")

## Summary by Sourcery

Build:
- Configure the deploy_to_itch reusable workflow to use Godot version 4.6.3-stable during deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to correct build system references and specify build tool version compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->