### PR TITLE
Replace brittle waits with deterministic polling

### DIFF
--- a/files/docs/milestones/22/Part_2_Replace_brittle_waits_with_deterministic_polling.md
+++ b/files/docs/milestones/22/Part_2_Replace_brittle_waits_with_deterministic_polling.md
@@ -1,0 +1,7 @@
+# Replace brittle waits with deterministic polling
+<!-- markdownlint-disable MD001 MD036 MD013 MD033 table-column-style -->
+
+
+
+---
+<!-- markdownlint-enable MD001 MD036 MD013 MD033 table-column-style -->

--- a/files/docs/milestones/22/Part_2_Replace_brittle_waits_with_deterministic_polling.md
+++ b/files/docs/milestones/22/Part_2_Replace_brittle_waits_with_deterministic_polling.md
@@ -71,6 +71,21 @@ Improvements include:
 - Normalized imports and formatting (multiple Black + isort passes)
 - Extracted duplicated helpers (e.g. `has_save_log`) into the shared utility module
 
+#### 6. Micro-Polling & Test Runner Hardening (Final Review Pass)
+
+- **Clock & Exception Safety (`tests/test_utils.py`):**
+  - Updated `wait_for_console_log` to measure elapsed polling time via `time.monotonic()`.
+  - Replaced `pytest.fail()` with `AssertionError` in `wait_for_console_log` to prevent timeout exceptions from bypassing test-level artifact capture (`except Exception:`).
+  - Centralized `has_save_log()` helper to check for encrypted/plaintext save entries.
+
+- **Race Condition & Persistence Fixes:**
+  - Synchronized `toggleMuteMaster([1])` and `toggleMuteSfx([1])` steps in `tests/audio_flow_test.py` with deterministic log polling.
+  - Added save-log synchronization prior to `page.reload()` in `tests/reset_audio_flow_test.py` (`STATE-01`) to guarantee async disk flushes complete before page reloads.
+  - Standardized callback argument signatures across test files (e.g. `window.audioPressed([])`).
+
+- **V8 Coverage Teardown Resilience:**
+  - Added `coverage_started` state tracking and isolated CDP profiler teardown in `finally` blocks using `try...except` handling, ensuring coverage harvesting failures never mask primary test assertion failures.
+
 ### Benefits
 
 - Dramatically reduced flakiness caused by race conditions and variable load times

--- a/files/docs/milestones/22/Part_2_Replace_brittle_waits_with_deterministic_polling.md
+++ b/files/docs/milestones/22/Part_2_Replace_brittle_waits_with_deterministic_polling.md
@@ -1,7 +1,131 @@
 # Replace brittle waits with deterministic polling
 <!-- markdownlint-disable MD001 MD036 MD013 MD033 table-column-style -->
 
+## PR #845 Summary: Replace brittle waits with deterministic polling
 
+**Repository:** [ikostan/SkyLockAssault](https://github.com/ikostan/SkyLockAssault)  
+**Author:** @ikostan  
+**Branch:** `code-audits-asynchronous-refactoring` → `main`  
+**Linked Issue:** [#772 – [TASK] Code Audits & Asynchronous Refactoring](https://github.com/ikostan/SkyLockAssault/issues/772)  
+**Milestone:** Milestone 22 – Optimize Test Suite Runtime & Fix Loading Screen  
+**Labels:** `enhancement`, `testing`, `refactoring`, `python`, `QA`
+
+### Purpose
+
+Eliminate timing-dependent flakiness in the Playwright browser E2E test suite by replacing all fixed-duration waits (`page.wait_for_timeout()`, arbitrary sleeps) with deterministic, state-based synchronization. The changes make tests wait for actual engine readiness, DOM visibility, or console-log events instead of relying on brittle timeouts.
+
+### Core Improvements
+
+#### 1. Deterministic Waiting & Assertions
+
+- Replaced every `page.wait_for_timeout()` with:
+  - `page.wait_for_function()` for Godot initialization (`window.godotInitialized === true`) and DOM style/display checks
+  - Playwright `expect(locator).to_be_visible()` for canvas, buttons, and overlays
+- Introduced reusable `wait_for_console_log(logs, predicate, start_idx, page)` helper that polls captured console messages with a predicate until the condition is met or a timeout occurs
+- Standardized console-log assertions (lower-cased matching, structured waiting) across volume, reset, audio, difficulty, back-navigation, and navigation tests
+- Strict equality check for Godot readiness (`=== true` instead of truthy)
+
+#### 2. Shared Test Utilities & Fixtures
+
+- Extracted common helpers and timeout constants into new module `tests/test_utils.py`
+- Centralized `DEFAULT_TIMEOUT` / `TEST_TIMEOUT` (environment-configurable)
+- Restructured `tests/conftest.py`:
+  - Session-scoped `browser_instance` fixture (single Chromium launch with GPU/WebGL flags)
+  - Function-scoped isolated `BrowserContext` + `Page` per test
+  - Optional HAR recording support via marker
+  - Full type annotations (`Browser`, `BrowserContext`, `Page`, `Generator`, etc.)
+
+#### 3. Test Coverage Stabilization
+
+Affected test files (all converted to deterministic waits):
+- `tests/audio_flow_test.py`
+- `tests/volume_sliders_mutes_test.py`
+- `tests/reset_audio_flow_test.py`
+- `tests/difficulty_flow_test.py`
+- `tests/back_flow_test.py`
+- `tests/navigation_to_audio_test.py`
+- `tests/load_main_menu_test.py`
+- `tests/no_error_logs_test.py`
+- `tests/validate_clean_load_test.py`
+
+Improvements include:
+
+- Explicit waiting for callback availability (`window.xxxPressed`)
+- Verification of menu transitions via `getComputedStyle(...).display`
+- Persistence checks after back-navigation and slider changes
+- Stricter “no unexpected errors” verification with clearer failure diagnostics (screenshots + captured logs)
+
+#### 4. Browser Test Runner Hardening (`workspace/run_browser_tests.sh`)
+
+- Added `git config --global --add safe.directory` to avoid “dubious ownership” errors in containers
+- Simplified and made robust the `git restore` of `export_presets.cfg` and `globals.gd`
+- Signal-aware cleanup (`trap` on `EXIT`/`INT`/`TERM`) for the background HTTP server
+- Increased server readiness polling frequency and timeout with clearer failure messages
+- Improved pytest invocation formatting and report-generation comments
+- Removed manual `kill` of server PID in favor of trap-based cleanup
+
+#### 5. Code Quality & Maintainability
+
+- Added comprehensive type hints (`Any`, `Callable`, `Generator`, `Dict`, `List`, `Optional`)
+- Removed verbose/redundant comments and outdated docstrings
+- Normalized imports and formatting (multiple Black + isort passes)
+- Extracted duplicated helpers (e.g. `has_save_log`) into the shared utility module
+
+### Benefits
+
+- Dramatically reduced flakiness caused by race conditions and variable load times
+- Faster overall suite runtime (shared browser launch + tighter, condition-driven waits)
+- Better isolation between tests while keeping startup overhead low
+- Clearer failure diagnostics and more maintainable test code
+- Improved CI reliability for browser-based E2E runs
+
+---
+
+## Reviewer's Guide
+
+Refactors Playwright-based E2E tests and the browser test runner to replace brittle fixed timeouts with deterministic state-based polling, introduce reusable console-log waiting helpers, improve fixtures and typing, and harden the CI shell script and server startup behavior.
+
+### File-Level Changes
+
+| Change                                                                                                                                | Details                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | Files                                                                                                                                                                                                                                                                                                                           |
+|---------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Introduce deterministic console-log polling helpers and replace ad-hoc log assertions based on fixed waits.                           | <ul><li>Add a wait_for_console_log(predicate, start_idx, timeout_ms) helper in multiple tests to poll captured console logs until a predicate matches or the timeout elapses.</li><li>Use wait_for_console_log instead of page.wait_for_timeout() followed by manual log slicing for all log-based assertions in volume, reset, audio, difficulty, back-flow, and navigation tests.</li><li>Standardize console assertion patterns to rely on lowercased log text and structured waiting, reducing log handling duplication and flakiness.</li></ul>                                                                                                                                                                  | `tests/volume_sliders_mutes_test.py`<br/>`tests/reset_audio_flow_test.py`<br/>`tests/audio_flow_test.py`<br/>`tests/difficulty_flow_test.py`<br/>`tests/back_flow_test.py`<br/>`tests/navigation_to_audio_test.py`                                                                                                              |
+| Replace arbitrary page.wait_for_timeout() calls with deterministic Playwright waits and expect() assertions for DOM and engine state. | <ul><li>Remove initial splash-scene waits and instead wait for window.godotInitialized === true using page.wait_for_function in all affected tests.</li><li>Switch canvas and overlay visibility checks from page.wait_for_selector() and manual style evaluation to expect(locator).to_be_visible() and page.wait_for_function() on specific style/display values.</li><li>Use page.wait_for_function() to verify slider value changes and menu transitions instead of time-based sleeps, including difficulty, audio back navigation, and reset flows.</li></ul>                                                                                                                                                    | `tests/volume_sliders_mutes_test.py`<br/>`tests/reset_audio_flow_test.py`<br/>`tests/audio_flow_test.py`<br/>`tests/difficulty_flow_test.py`<br/>`tests/back_flow_test.py`<br/>`tests/navigation_to_audio_test.py`<br/>`tests/load_main_menu_test.py`<br/>`tests/no_error_logs_test.py`<br/>`tests/validate_clean_load_test.py` |
+| Refine Godot initialization and DOM overlay checks to be explicit and robust.                                                         | <ul><li>Change initialization checks from truthy window.godotInitialized to strict window.godotInitialized === true for all tests.</li><li>Ensure main-menu and options DOM overlays are asserted using Playwright expect() and explicit style checks, rather than comments or loose visibility assumptions.</li><li>Tighten checks around gameplay/audio/options menu transitions by explicitly asserting display style changes (block/none) after back and navigation actions.</li></ul>                                                                                                                                                                                                                            | `tests/volume_sliders_mutes_test.py`<br/>`tests/reset_audio_flow_test.py`<br/>`tests/audio_flow_test.py`<br/>`tests/difficulty_flow_test.py`<br/>`tests/back_flow_test.py`<br/>`tests/navigation_to_audio_test.py`<br/>`tests/load_main_menu_test.py`<br/>`tests/validate_clean_load_test.py`                                   |
+| Restructure pytest fixtures to reuse a session-scoped browser and provide function-scoped, isolated contexts and pages.               | <ul><li>Introduce a session-scoped browser_instance fixture that launches Chromium once with the required GPU/WebGL flags and yields the Browser.</li><li>Refactor the page fixture to depend on browser_instance, creating a new BrowserContext and Page per test, with optional HAR recording based on a record_har marker.</li><li>Add typing to fixtures (Browser, BrowserContext, Page, Generator, pytest.FixtureRequest, pytest.Config) and clean up browser lifecycle to close only contexts per test and the browser at session end.</li></ul>                                                                                                                                                                | `tests/conftest.py`                                                                                                                                                                                                                                                                                                             |
+| Improve typing, imports, and comment clarity across tests.                                                                            | <ul><li>Add typing imports such as Any, Callable, Generator, Dict, List, Optional where appropriate and annotate console handlers and helper functions.</li><li>Import pytest and Playwright expect API in tests that use them, and remove redundant or overly verbose docstrings and comments that no longer reflect behavior.</li><li>Normalize DEFAULT_TIMEOUT/TEST_TIMEOUT definitions and remove outdated comments about fallback behavior or CLI feature flags that are now enforced elsewhere.</li></ul>                                                                                                                                                                                                       | `tests/volume_sliders_mutes_test.py`<br/>`tests/reset_audio_flow_test.py`<br/>`tests/audio_flow_test.py`<br/>`tests/difficulty_flow_test.py`<br/>`tests/back_flow_test.py`<br/>`tests/navigation_to_audio_test.py`<br/>`tests/conftest.py`                                                                                      |
+| Harden the browser test runner shell script for CI reliability and cleanup.                                                           | <ul><li>Configure git safe.directory for the project path to avoid dubious ownership errors in containers before running modifications.</li><li>Simplify git restore to restore both export_presets.cfg and globals.gd in a single command with error checking.</li><li>Add a trap on EXIT/INT/TERM to reliably kill the background HTTP server, increase server readiness polling frequency and timeout, and restructure the curl-based readiness loop with clear failure messaging.</li><li>Reformat the pytest invocation with line breaks for readability and explicitly comment the report generation section.</li><li>Remove manual kill of SERVER_PID at the end in favor of the trap-based cleanup.</li></ul> | `workspace/run_browser_tests.sh`                                                                                                                                                                                                                                                                                                |
+
+### Assessment against linked issues
+
+| Issue                                                | Objective                                                                                                                                                                                                                                                                                | Addressed | Explanation |
+|------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|-------------|
+| https://github.com/ikostan/SkyLockAssault/issues/772 | Refactor Playwright browser tests in tests/ to replace arbitrary static waits (e.g., page.wait_for_timeout/time.sleep) with deterministic synchronization using Playwright wait_for_function/expect and console-log/event predicates, while preserving existing assertions and behavior. | ✅        |             |
+| https://github.com/ikostan/SkyLockAssault/issues/772 | Streamline pytest fixtures in tests/conftest.py to use an optimized browser lifecycle (session-scoped browser, function-scoped contexts/pages) and improve maintainability.                                                                                                              | ✅        |             |
+| https://github.com/ikostan/SkyLockAssault/issues/772 | Improve workspace/run_browser_tests.sh to reduce unnecessary startup/readiness overhead and make CI/browser test execution more robust (server startup checks, cleanup, Git safety, etc.).                                                                                               | ✅        |             |
+
+### Possibly linked issues
+
+- **#TASK**: PR directly addresses the test wait refactors, fixture lifecycle changes, and runner optimizations specified in the issue.
+- **#N/A**: PR implements audio_flow_test with WARN-01–03 using DOM overlays and log assertions, matching the feature request.
+
+---
+
+### AI / Bot Contributors
+
+- **@sourcery-ai**  
+  Generated the PR summary and Reviewer's Guide. Performed code review identifying duplication of `wait_for_console_log`, suggesting extraction to a shared utility, recommending Playwright locator assertions over raw JS `wait_for_function` checks, and noting potential tracing cleanup for session-scoped browser fixtures.
+- **@coderabbitai**  
+  Generated the PR summary and detailed walkthrough. Conducted multiple rounds of code review with actionable suggestions (timeout centralization, helper extraction, assertion improvements, shell-script hardening). Co-authored commits updating `workspace/run_browser_tests.sh`.
+- **@deepsource-io**  
+  Performed automated code review, published a PR Report Card (Security / Reliability / Complexity / Hygiene), and provided analysis status for Python and JavaScript.
+- **@deepsource-autofix**  
+  Authored multiple automated style/format commits (`style: format code with Black and isort`) to enforce formatting consistency across test files.
+
+### Human Contributor
+
+- **@ikostan**  
+  Primary author of the PR. Implemented the core refactor (deterministic polling with `wait_for_function` / `expect()`, `wait_for_console_log` helper, session-scoped browser + function-scoped contexts, type hints, and hardened `run_browser_tests.sh`). Authored the majority of commits, addressed review feedback, extracted shared utilities to `tests/test_utils.py`, and created supporting documentation.
 
 ---
 <!-- markdownlint-enable MD001 MD036 MD013 MD033 table-column-style -->

--- a/tests/audio_flow_test.py
+++ b/tests/audio_flow_test.py
@@ -59,7 +59,7 @@ def test_audio_flow(page: Page) -> None:
     page.on("console", on_console)
 
     def wait_for_console_log(
-            predicate: Callable[[str], bool], start_idx: int, timeout_ms: int = TEST_TIMEOUT
+        predicate: Callable[[str], bool], start_idx: int, timeout_ms: int = TEST_TIMEOUT
     ) -> None:
         """Helper to poll until a matching console log arrives or timeout expires."""
         start_time = time.time()
@@ -149,7 +149,7 @@ def test_audio_flow(page: Page) -> None:
             ").display === 'block'",
             timeout=TEST_TIMEOUT,
         )
-        
+
         wait_for_console_log(
             lambda text: "audio button pressed" in text,
             start_idx=pre_change_log_count,

--- a/tests/audio_flow_test.py
+++ b/tests/audio_flow_test.py
@@ -68,7 +68,8 @@ def test_audio_flow(page: Page) -> None:
                 return
             page.wait_for_timeout(50)  # Micro-poll for event loop progression
         pytest.fail(
-            f"Timed out waiting for expected console log matching predicate after {timeout_ms}ms"
+            "Timed out waiting for expected console log matching "
+            f"predicate after {timeout_ms}ms"
         )
 
     try:

--- a/tests/audio_flow_test.py
+++ b/tests/audio_flow_test.py
@@ -112,10 +112,11 @@ def test_audio_flow(page: Page) -> None:
         )
 
         page.wait_for_function(
-            "() => window.getComputedStyle(document.getElementById('log-level-select')).display === 'block'",
+            "() => window.getComputedStyle("
+            "document.getElementById('log-level-select')"
+            ").display === 'block'",
             timeout=TEST_TIMEOUT,
         )
-
         # Set log level DEBUG
         pre_change_log_count = len(logs)
         page.evaluate("window.changeLogLevel([0])")

--- a/tests/audio_flow_test.py
+++ b/tests/audio_flow_test.py
@@ -28,12 +28,10 @@ v8_coverage_audio_flow_test.json, artifacts/test_audio_failure_*.png/txt
 import json
 import os
 import time
-
+from typing import Any, Callable
 import pytest
-from playwright.sync_api import Page
+from playwright.sync_api import Page, expect
 
-# Configuration for stability in different environments
-# Default to 5000ms, but allow CI to override via environment variable
 DEFAULT_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "30000"))
 TEST_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "5000"))
 
@@ -42,30 +40,29 @@ TEST_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "5000"))
 def test_audio_flow(page: Page) -> None:
     """
     Main test for warning popups and constraints using DOM overlays.
-
     Implements WARN-01 to WARN-03: Mute/adjust, verify unchanged values, warning logs.
-
-    :param page: The Playwright page object.
-    :type page: Page
-    :return: None
-    :rtype: None
     """
     logs: list[dict[str, str]] = []
     cdp_session = None
 
-    def on_console(msg) -> None:
-        """
-        Console message handler.
-
-        :param msg: The console message.
-        :type msg: Any
-        :rtype: None
-        """
+    def on_console(msg: Any) -> None:
         logs.append({"type": msg.type, "text": msg.text})
 
     page.on("console", on_console)
+
+    def wait_for_console_log(predicate: Callable[[str], bool], start_idx: int, timeout_ms: int = TEST_TIMEOUT) -> None:
+        """
+        Helper to poll until a matching console log arrives or timeout expires.
+        """
+        start_time = time.time()
+        while (time.time() - start_time) * 1000 < timeout_ms:
+            if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
+                return
+            page.wait_for_timeout(50)  # Micro-poll for event loop progression
+        pytest.fail(f"Timed out waiting for expected console log matching predicate after {timeout_ms}ms")
+
     try:
-        # Start CDP session for V8 JS coverage (workaround for Python Playwright lacking native coverage API)
+        # Start CDP session for V8 JS coverage
         cdp_session = page.context.new_cdp_session(page)
         cdp_session.send("Profiler.enable")
         cdp_session.send(
@@ -77,230 +74,162 @@ def test_audio_flow(page: Page) -> None:
             wait_until="networkidle",
             timeout=DEFAULT_TIMEOUT,
         )
-        # 1. Wait for the engine to actually start the splash scene
-        page.wait_for_timeout(TEST_TIMEOUT)
-        page.wait_for_function("() => window.godotInitialized", timeout=DEFAULT_TIMEOUT)
 
-        # Verify canvas
+        # 1. Wait deterministically for Godot engine initialization
+        page.wait_for_function("() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT)
+
+        # Verify canvas & title
         canvas = page.locator("canvas")
-        page.wait_for_selector("canvas", state="visible", timeout=DEFAULT_TIMEOUT)
-        box: dict[str, float] | None = canvas.bounding_box()
-        assert box is not None, "Canvas not found"
+        expect(canvas).to_be_visible(timeout=DEFAULT_TIMEOUT)
         assert "SkyLockAssault" in page.title(), "Title not found"
 
         # Open options
-        page.wait_for_selector("#options-button", state="visible", timeout=TEST_TIMEOUT)
-        # page.click("#options-button", force=True)
-        page.wait_for_function(
-            "window.optionsPressed !== undefined", timeout=TEST_TIMEOUT
-        )
+        page.wait_for_function("() => typeof window.optionsPressed !== 'undefined'", timeout=TEST_TIMEOUT)
         page.evaluate("window.optionsPressed([])")
 
         # Go to Advanced settings
-        page.wait_for_selector(
-            "#advanced-button", state="visible", timeout=TEST_TIMEOUT
-        )
-        # page.click("#advanced-button", force=True)
-        page.wait_for_function(
-            "window.advancedPressed !== undefined", timeout=TEST_TIMEOUT
-        )
+        page.wait_for_function("() => typeof window.advancedPressed !== 'undefined'", timeout=TEST_TIMEOUT)
         page.evaluate("window.advancedPressed([])")
+        page.wait_for_function("() => typeof window.changeLogLevel !== 'undefined'", timeout=TEST_TIMEOUT)
+
         page.wait_for_function(
-            "window.changeLogLevel !== undefined", timeout=TEST_TIMEOUT
+            "() => window.getComputedStyle(document.getElementById('log-level-select')).display === 'block'",
+            timeout=TEST_TIMEOUT,
         )
-        advanced_display: str = page.evaluate(
-            "window.getComputedStyle(document.getElementById('log-level-select')).display"
-        )
-        assert (
-            advanced_display == "block"
-        ), "Advanced menu not loaded (selected log level not displayed)"
 
         # Set log level DEBUG
         pre_change_log_count = len(logs)
         page.evaluate("window.changeLogLevel([0])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        new_logs = logs[pre_change_log_count:]
-        assert any(
-            "log level changed to: debug" in log["text"].lower() for log in new_logs
+        wait_for_console_log(
+            lambda text: "log level changed to: debug" in text,
+            start_idx=pre_change_log_count,
         )
+
         assert page.evaluate(
             "document.getElementById('audio-button') !== null"
         ), "Audio button not found/displayed"
 
         # Go back to Options menu
-        page.wait_for_selector(
-            "#advanced-back-button", state="visible", timeout=TEST_TIMEOUT
-        )
-        # page.click("#advanced-back-button", force=True)
-        page.wait_for_function(
-            "window.advancedBackPressed !== undefined", timeout=TEST_TIMEOUT
-        )
+        page.wait_for_function("() => typeof window.advancedBackPressed !== 'undefined'", timeout=TEST_TIMEOUT)
         page.evaluate("window.advancedBackPressed([])")
 
         # Open audio
         pre_change_log_count = len(logs)
-        page.wait_for_selector("#audio-button", state="visible", timeout=TEST_TIMEOUT)
-        # page.click("#audio-button", force=True)
-        page.wait_for_function(
-            "window.audioPressed !== undefined", timeout=TEST_TIMEOUT
-        )
+        page.wait_for_function("() => typeof window.audioPressed !== 'undefined'", timeout=TEST_TIMEOUT)
         page.evaluate("window.audioPressed([])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        assert (
-            page.evaluate(
-                "window.getComputedStyle(document.getElementById('master-slider')).display"
-            )
-            == "block"
+
+        page.wait_for_function(
+            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'block'",
+            timeout=TEST_TIMEOUT,
         )
-        new_logs = logs[pre_change_log_count:]
-        assert any("audio button pressed" in log["text"].lower() for log in new_logs)
+        wait_for_console_log(
+            lambda text: "audio button pressed" in text,
+            start_idx=pre_change_log_count,
+        )
 
         # Get initial values
         initial_sfx: str = page.evaluate("document.getElementById('sfx-slider').value")
-        initial_weapon: str = page.evaluate(
-            "document.getElementById('weapon-slider').value"
-        )
-        initial_music: str = page.evaluate(
-            "document.getElementById('music-slider').value"
-        )
-        initial_rotors: str = page.evaluate(
-            "document.getElementById('rotors-slider').value"
-        )
+        initial_weapon: str = page.evaluate("document.getElementById('weapon-slider').value")
+        initial_music: str = page.evaluate("document.getElementById('music-slider').value")
+        initial_rotors: str = page.evaluate("document.getElementById('rotors-slider').value")
 
         # WARN-01: Master muted → attempt sub-volume adjust (SFX)
         pre_change_log_count = len(logs)
-        page.wait_for_function(
-            "window.toggleMuteMaster !== undefined", timeout=TEST_TIMEOUT
-        )
+        page.wait_for_function("() => typeof window.toggleMuteMaster !== 'undefined'", timeout=TEST_TIMEOUT)
         page.evaluate("window.toggleMuteMaster([0])")  # Mute
-        page.wait_for_timeout(TEST_TIMEOUT)
-        new_logs = logs[pre_change_log_count:]
-        assert any("master is muted" in log["text"].lower() for log in new_logs)
+        wait_for_console_log(
+            lambda text: "master is muted" in text,
+            start_idx=pre_change_log_count,
+        )
+
         # Change SFX Volume when Master is muted
         pre_change_log_count = len(logs)
-        page.wait_for_function(
-            "window.changeSfxVolume !== undefined", timeout=TEST_TIMEOUT
-        )
+        page.wait_for_function("() => typeof window.changeSfxVolume !== 'undefined'", timeout=TEST_TIMEOUT)
         page.evaluate("window.changeSfxVolume([0])")
-        page.wait_for_timeout(TEST_TIMEOUT)
+        wait_for_console_log(
+            lambda text: "master muted, cannot adjust sub-volume" in text or "warning dialog" in text,
+            start_idx=pre_change_log_count,
+        )
         assert (
-            page.evaluate("document.getElementById('sfx-slider').value") == initial_sfx
+                page.evaluate("document.getElementById('sfx-slider').value") == initial_sfx
         ), "SFX value changed unexpectedly"
-        new_logs = logs[pre_change_log_count:]
-        assert any(
-            "master muted, cannot adjust sub-volume" in log["text"].lower()
-            for log in new_logs
-        ) or any("warning dialog" in log["text"].lower() for log in new_logs)
 
-        # Additional: Master muted → attempt sub-volume adjust (Music)
-        # Attempt to change music while Master is still muted
+        # Master muted → attempt sub-volume adjust (Music)
         pre_change_log_count = len(logs)
-        page.wait_for_function(
-            "window.changeMusicVolume !== undefined", timeout=TEST_TIMEOUT
-        )
+        page.wait_for_function("() => typeof window.changeMusicVolume !== 'undefined'", timeout=TEST_TIMEOUT)
         page.evaluate("window.changeMusicVolume([0.3])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        assert (
-            page.evaluate("document.getElementById('music-slider').value")
-            == initial_music
-        ), "Music value changed unexpectedly under Master mute"
-        new_logs = logs[pre_change_log_count:]
-        assert any(
-            "master muted, cannot adjust sub-volume" in log["text"].lower()
-            for log in new_logs
-        ) or any("warning dialog" in log["text"].lower() for log in new_logs)
-
-        # Additional: Master muted → attempt sub-volume adjust (Rotors)
-        # Assuming Rotors is affected by Master mute (as a deeper sub-volume)
-        pre_change_log_count = len(logs)
-        page.wait_for_function(
-            "window.changeRotorsVolume !== undefined", timeout=TEST_TIMEOUT
+        wait_for_console_log(
+            lambda text: "master muted, cannot adjust sub-volume" in text or "warning dialog" in text,
+            start_idx=pre_change_log_count,
         )
-        page.evaluate("window.changeRotorsVolume([0.4])")
-        page.wait_for_timeout(TEST_TIMEOUT)
         assert (
-            page.evaluate("document.getElementById('rotors-slider').value")
-            == initial_rotors
+                page.evaluate("document.getElementById('music-slider').value") == initial_music
+        ), "Music value changed unexpectedly under Master mute"
+
+        # Master muted → attempt sub-volume adjust (Rotors)
+        pre_change_log_count = len(logs)
+        page.wait_for_function("() => typeof window.changeRotorsVolume !== 'undefined'", timeout=TEST_TIMEOUT)
+        page.evaluate("window.changeRotorsVolume([0.4])")
+        wait_for_console_log(
+            lambda text: "master muted, cannot adjust sub-volume" in text or "warning dialog" in text,
+            start_idx=pre_change_log_count,
+        )
+        assert (
+                page.evaluate("document.getElementById('rotors-slider').value") == initial_rotors
         ), "Rotors value changed unexpectedly under Master mute"
-        new_logs = logs[pre_change_log_count:]
-        assert any(
-            "master muted, cannot adjust sub-volume" in log["text"].lower()
-            for log in new_logs
-        ) or any("warning dialog" in log["text"].lower() for log in new_logs)
 
         # Unmute Master for next tests
-        page.wait_for_function(
-            "window.toggleMuteMaster !== undefined", timeout=TEST_TIMEOUT
-        )
+        page.wait_for_function("() => typeof window.toggleMuteMaster !== 'undefined'", timeout=TEST_TIMEOUT)
         page.evaluate("window.toggleMuteMaster([1])")
-        page.wait_for_timeout(TEST_TIMEOUT)
 
         # WARN-02: SFX muted → attempt weapon adjust
-        page.wait_for_function(
-            "window.toggleMuteSfx !== undefined", timeout=TEST_TIMEOUT
-        )
+        page.wait_for_function("() => typeof window.toggleMuteSfx !== 'undefined'", timeout=TEST_TIMEOUT)
         page.evaluate("window.toggleMuteSfx([0])")  # Mute
-        page.wait_for_timeout(TEST_TIMEOUT)
-        pre_change_log_count = len(logs)
-        page.wait_for_function(
-            "window.changeWeaponVolume !== undefined", timeout=TEST_TIMEOUT
-        )
-        page.evaluate("window.changeWeaponVolume([0])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        assert (
-            page.evaluate("document.getElementById('weapon-slider').value")
-            == initial_weapon
-        ), "Weapon value changed unexpectedly"
-        new_logs = logs[pre_change_log_count:]
-        assert any(
-            "sfx muted, cannot adjust" in log["text"].lower() for log in new_logs
-        ) or any("warning dialog" in log["text"].lower() for log in new_logs)
 
-        # Additional: SFX muted → attempt rotors adjust (assuming Rotors under SFX)
         pre_change_log_count = len(logs)
-        page.wait_for_function(
-            "window.changeRotorsVolume !== undefined", timeout=TEST_TIMEOUT
+        page.wait_for_function("() => typeof window.changeWeaponVolume !== 'undefined'", timeout=TEST_TIMEOUT)
+        page.evaluate("window.changeWeaponVolume([0])")
+        wait_for_console_log(
+            lambda text: "sfx muted, cannot adjust" in text or "warning dialog" in text,
+            start_idx=pre_change_log_count,
         )
-        page.evaluate("window.changeRotorsVolume([0.5])")
-        page.wait_for_timeout(TEST_TIMEOUT)
         assert (
-            page.evaluate("document.getElementById('rotors-slider').value")
-            == initial_rotors
+                page.evaluate("document.getElementById('weapon-slider').value") == initial_weapon
+        ), "Weapon value changed unexpectedly"
+
+        # SFX muted → attempt rotors adjust
+        pre_change_log_count = len(logs)
+        page.wait_for_function("() => typeof window.changeRotorsVolume !== 'undefined'", timeout=TEST_TIMEOUT)
+        page.evaluate("window.changeRotorsVolume([0.5])")
+        wait_for_console_log(
+            lambda text: "sfx muted, cannot adjust" in text or "warning dialog" in text,
+            start_idx=pre_change_log_count,
+        )
+        assert (
+                page.evaluate("document.getElementById('rotors-slider').value") == initial_rotors
         ), "Rotors value changed unexpectedly under SFX mute"
-        new_logs = logs[pre_change_log_count:]
-        assert any(
-            "sfx muted, cannot adjust" in log["text"].lower() for log in new_logs
-        ) or any("warning dialog" in log["text"].lower() for log in new_logs)
 
         # Unmute SFX
-        page.wait_for_function(
-            "window.toggleMuteSfx !== undefined", timeout=TEST_TIMEOUT
-        )
+        page.wait_for_function("() => typeof window.toggleMuteSfx !== 'undefined'", timeout=TEST_TIMEOUT)
         page.evaluate("window.toggleMuteSfx([1])")
-        page.wait_for_timeout(TEST_TIMEOUT)
 
         # WARN-03: Master unmuted → adjust sub-volume (Music)
-        # Capture logs before the change to isolate new ones (good for debugging in Godot tests)
         pre_change_log_count = len(logs)
-        page.wait_for_function(
-            "window.changeMusicVolume !== undefined", timeout=TEST_TIMEOUT
-        )
+        page.wait_for_function("() => typeof window.changeMusicVolume !== 'undefined'", timeout=TEST_TIMEOUT)
         page.evaluate("window.changeMusicVolume([0.6])")
-        page.wait_for_timeout(TEST_TIMEOUT)
 
-        # Verify the value changed (as expected, no mute constraint)
-        assert (
-            page.evaluate("document.getElementById('music-slider').value") == "0.6"
-        ), "Music value not changed"
+        # Deterministic check for value update
+        page.wait_for_function(
+            "() => document.getElementById('music-slider').value === '0.6'",
+            timeout=TEST_TIMEOUT,
+        )
 
-        # Check only new logs for no warnings, ignoring known encryption fallbacks
+        # Ensure no unexpected warning logs were generated
         new_logs = logs[pre_change_log_count:]
         for log in new_logs:
             text = log["text"].lower()
             if "warning" in text and "encryption aborted" not in text:
-                assert (
-                    False
-                ), f"Unexpected warning after music volume change: {log['text']}"
+                assert False, f"Unexpected warning after music volume change: {log['text']}"
 
     except Exception as e:
         print(f"Test: 'test_audio_flow' failed: {str(e)}")
@@ -316,7 +245,6 @@ def test_audio_flow(page: Page) -> None:
         raise
     finally:
         if cdp_session:
-            # Stop V8 coverage and save to file (even on failure)
             coverage = cdp_session.send("Profiler.takePreciseCoverage")["result"]
             cdp_session.send("Profiler.stopPreciseCoverage")
             cdp_session.send("Profiler.disable")

--- a/tests/audio_flow_test.py
+++ b/tests/audio_flow_test.py
@@ -47,6 +47,13 @@ def test_audio_flow(page: Page) -> None:
     cdp_session = None
 
     def on_console(msg: Any) -> None:
+        """
+        Console message handler to capture logs.
+
+        :param msg: The console message.
+        :type msg: Any
+        :rtype: None
+        """
         logs.append({"type": msg.type, "text": msg.text})
 
     page.on("console", on_console)

--- a/tests/audio_flow_test.py
+++ b/tests/audio_flow_test.py
@@ -59,11 +59,9 @@ def test_audio_flow(page: Page) -> None:
     page.on("console", on_console)
 
     def wait_for_console_log(
-        predicate: Callable[[str], bool], start_idx: int, timeout_ms: int = TEST_TIMEOUT
+            predicate: Callable[[str], bool], start_idx: int, timeout_ms: int = TEST_TIMEOUT
     ) -> None:
-        """
-        Helper to poll until a matching console log arrives or timeout expires.
-        """
+        """Helper to poll until a matching console log arrives or timeout expires."""
         start_time = time.time()
         while (time.time() - start_time) * 1000 < timeout_ms:
             if any(predicate(log["text"].lower()) for log in logs[start_idx:]):

--- a/tests/audio_flow_test.py
+++ b/tests/audio_flow_test.py
@@ -29,6 +29,7 @@ import json
 import os
 import time
 from typing import Any, Callable
+
 import pytest
 from playwright.sync_api import Page, expect
 
@@ -50,7 +51,9 @@ def test_audio_flow(page: Page) -> None:
 
     page.on("console", on_console)
 
-    def wait_for_console_log(predicate: Callable[[str], bool], start_idx: int, timeout_ms: int = TEST_TIMEOUT) -> None:
+    def wait_for_console_log(
+        predicate: Callable[[str], bool], start_idx: int, timeout_ms: int = TEST_TIMEOUT
+    ) -> None:
         """
         Helper to poll until a matching console log arrives or timeout expires.
         """
@@ -59,7 +62,9 @@ def test_audio_flow(page: Page) -> None:
             if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
                 return
             page.wait_for_timeout(50)  # Micro-poll for event loop progression
-        pytest.fail(f"Timed out waiting for expected console log matching predicate after {timeout_ms}ms")
+        pytest.fail(
+            f"Timed out waiting for expected console log matching predicate after {timeout_ms}ms"
+        )
 
     try:
         # Start CDP session for V8 JS coverage
@@ -76,7 +81,9 @@ def test_audio_flow(page: Page) -> None:
         )
 
         # 1. Wait deterministically for Godot engine initialization
-        page.wait_for_function("() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT)
+        page.wait_for_function(
+            "() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT
+        )
 
         # Verify canvas & title
         canvas = page.locator("canvas")
@@ -84,13 +91,19 @@ def test_audio_flow(page: Page) -> None:
         assert "SkyLockAssault" in page.title(), "Title not found"
 
         # Open options
-        page.wait_for_function("() => typeof window.optionsPressed !== 'undefined'", timeout=TEST_TIMEOUT)
+        page.wait_for_function(
+            "() => typeof window.optionsPressed !== 'undefined'", timeout=TEST_TIMEOUT
+        )
         page.evaluate("window.optionsPressed([])")
 
         # Go to Advanced settings
-        page.wait_for_function("() => typeof window.advancedPressed !== 'undefined'", timeout=TEST_TIMEOUT)
+        page.wait_for_function(
+            "() => typeof window.advancedPressed !== 'undefined'", timeout=TEST_TIMEOUT
+        )
         page.evaluate("window.advancedPressed([])")
-        page.wait_for_function("() => typeof window.changeLogLevel !== 'undefined'", timeout=TEST_TIMEOUT)
+        page.wait_for_function(
+            "() => typeof window.changeLogLevel !== 'undefined'", timeout=TEST_TIMEOUT
+        )
 
         page.wait_for_function(
             "() => window.getComputedStyle(document.getElementById('log-level-select')).display === 'block'",
@@ -110,12 +123,17 @@ def test_audio_flow(page: Page) -> None:
         ), "Audio button not found/displayed"
 
         # Go back to Options menu
-        page.wait_for_function("() => typeof window.advancedBackPressed !== 'undefined'", timeout=TEST_TIMEOUT)
+        page.wait_for_function(
+            "() => typeof window.advancedBackPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
+        )
         page.evaluate("window.advancedBackPressed([])")
 
         # Open audio
         pre_change_log_count = len(logs)
-        page.wait_for_function("() => typeof window.audioPressed !== 'undefined'", timeout=TEST_TIMEOUT)
+        page.wait_for_function(
+            "() => typeof window.audioPressed !== 'undefined'", timeout=TEST_TIMEOUT
+        )
         page.evaluate("window.audioPressed([])")
 
         page.wait_for_function(
@@ -129,13 +147,21 @@ def test_audio_flow(page: Page) -> None:
 
         # Get initial values
         initial_sfx: str = page.evaluate("document.getElementById('sfx-slider').value")
-        initial_weapon: str = page.evaluate("document.getElementById('weapon-slider').value")
-        initial_music: str = page.evaluate("document.getElementById('music-slider').value")
-        initial_rotors: str = page.evaluate("document.getElementById('rotors-slider').value")
+        initial_weapon: str = page.evaluate(
+            "document.getElementById('weapon-slider').value"
+        )
+        initial_music: str = page.evaluate(
+            "document.getElementById('music-slider').value"
+        )
+        initial_rotors: str = page.evaluate(
+            "document.getElementById('rotors-slider').value"
+        )
 
         # WARN-01: Master muted → attempt sub-volume adjust (SFX)
         pre_change_log_count = len(logs)
-        page.wait_for_function("() => typeof window.toggleMuteMaster !== 'undefined'", timeout=TEST_TIMEOUT)
+        page.wait_for_function(
+            "() => typeof window.toggleMuteMaster !== 'undefined'", timeout=TEST_TIMEOUT
+        )
         page.evaluate("window.toggleMuteMaster([0])")  # Mute
         wait_for_console_log(
             lambda text: "master is muted" in text,
@@ -144,78 +170,108 @@ def test_audio_flow(page: Page) -> None:
 
         # Change SFX Volume when Master is muted
         pre_change_log_count = len(logs)
-        page.wait_for_function("() => typeof window.changeSfxVolume !== 'undefined'", timeout=TEST_TIMEOUT)
+        page.wait_for_function(
+            "() => typeof window.changeSfxVolume !== 'undefined'", timeout=TEST_TIMEOUT
+        )
         page.evaluate("window.changeSfxVolume([0])")
         wait_for_console_log(
-            lambda text: "master muted, cannot adjust sub-volume" in text or "warning dialog" in text,
+            lambda text: "master muted, cannot adjust sub-volume" in text
+            or "warning dialog" in text,
             start_idx=pre_change_log_count,
         )
         assert (
-                page.evaluate("document.getElementById('sfx-slider').value") == initial_sfx
+            page.evaluate("document.getElementById('sfx-slider').value") == initial_sfx
         ), "SFX value changed unexpectedly"
 
         # Master muted → attempt sub-volume adjust (Music)
         pre_change_log_count = len(logs)
-        page.wait_for_function("() => typeof window.changeMusicVolume !== 'undefined'", timeout=TEST_TIMEOUT)
+        page.wait_for_function(
+            "() => typeof window.changeMusicVolume !== 'undefined'",
+            timeout=TEST_TIMEOUT,
+        )
         page.evaluate("window.changeMusicVolume([0.3])")
         wait_for_console_log(
-            lambda text: "master muted, cannot adjust sub-volume" in text or "warning dialog" in text,
+            lambda text: "master muted, cannot adjust sub-volume" in text
+            or "warning dialog" in text,
             start_idx=pre_change_log_count,
         )
         assert (
-                page.evaluate("document.getElementById('music-slider').value") == initial_music
+            page.evaluate("document.getElementById('music-slider').value")
+            == initial_music
         ), "Music value changed unexpectedly under Master mute"
 
         # Master muted → attempt sub-volume adjust (Rotors)
         pre_change_log_count = len(logs)
-        page.wait_for_function("() => typeof window.changeRotorsVolume !== 'undefined'", timeout=TEST_TIMEOUT)
+        page.wait_for_function(
+            "() => typeof window.changeRotorsVolume !== 'undefined'",
+            timeout=TEST_TIMEOUT,
+        )
         page.evaluate("window.changeRotorsVolume([0.4])")
         wait_for_console_log(
-            lambda text: "master muted, cannot adjust sub-volume" in text or "warning dialog" in text,
+            lambda text: "master muted, cannot adjust sub-volume" in text
+            or "warning dialog" in text,
             start_idx=pre_change_log_count,
         )
         assert (
-                page.evaluate("document.getElementById('rotors-slider').value") == initial_rotors
+            page.evaluate("document.getElementById('rotors-slider').value")
+            == initial_rotors
         ), "Rotors value changed unexpectedly under Master mute"
 
         # Unmute Master for next tests
-        page.wait_for_function("() => typeof window.toggleMuteMaster !== 'undefined'", timeout=TEST_TIMEOUT)
+        page.wait_for_function(
+            "() => typeof window.toggleMuteMaster !== 'undefined'", timeout=TEST_TIMEOUT
+        )
         page.evaluate("window.toggleMuteMaster([1])")
 
         # WARN-02: SFX muted → attempt weapon adjust
-        page.wait_for_function("() => typeof window.toggleMuteSfx !== 'undefined'", timeout=TEST_TIMEOUT)
+        page.wait_for_function(
+            "() => typeof window.toggleMuteSfx !== 'undefined'", timeout=TEST_TIMEOUT
+        )
         page.evaluate("window.toggleMuteSfx([0])")  # Mute
 
         pre_change_log_count = len(logs)
-        page.wait_for_function("() => typeof window.changeWeaponVolume !== 'undefined'", timeout=TEST_TIMEOUT)
+        page.wait_for_function(
+            "() => typeof window.changeWeaponVolume !== 'undefined'",
+            timeout=TEST_TIMEOUT,
+        )
         page.evaluate("window.changeWeaponVolume([0])")
         wait_for_console_log(
             lambda text: "sfx muted, cannot adjust" in text or "warning dialog" in text,
             start_idx=pre_change_log_count,
         )
         assert (
-                page.evaluate("document.getElementById('weapon-slider').value") == initial_weapon
+            page.evaluate("document.getElementById('weapon-slider').value")
+            == initial_weapon
         ), "Weapon value changed unexpectedly"
 
         # SFX muted → attempt rotors adjust
         pre_change_log_count = len(logs)
-        page.wait_for_function("() => typeof window.changeRotorsVolume !== 'undefined'", timeout=TEST_TIMEOUT)
+        page.wait_for_function(
+            "() => typeof window.changeRotorsVolume !== 'undefined'",
+            timeout=TEST_TIMEOUT,
+        )
         page.evaluate("window.changeRotorsVolume([0.5])")
         wait_for_console_log(
             lambda text: "sfx muted, cannot adjust" in text or "warning dialog" in text,
             start_idx=pre_change_log_count,
         )
         assert (
-                page.evaluate("document.getElementById('rotors-slider').value") == initial_rotors
+            page.evaluate("document.getElementById('rotors-slider').value")
+            == initial_rotors
         ), "Rotors value changed unexpectedly under SFX mute"
 
         # Unmute SFX
-        page.wait_for_function("() => typeof window.toggleMuteSfx !== 'undefined'", timeout=TEST_TIMEOUT)
+        page.wait_for_function(
+            "() => typeof window.toggleMuteSfx !== 'undefined'", timeout=TEST_TIMEOUT
+        )
         page.evaluate("window.toggleMuteSfx([1])")
 
         # WARN-03: Master unmuted → adjust sub-volume (Music)
         pre_change_log_count = len(logs)
-        page.wait_for_function("() => typeof window.changeMusicVolume !== 'undefined'", timeout=TEST_TIMEOUT)
+        page.wait_for_function(
+            "() => typeof window.changeMusicVolume !== 'undefined'",
+            timeout=TEST_TIMEOUT,
+        )
         page.evaluate("window.changeMusicVolume([0.6])")
 
         # Deterministic check for value update
@@ -229,7 +285,9 @@ def test_audio_flow(page: Page) -> None:
         for log in new_logs:
             text = log["text"].lower()
             if "warning" in text and "encryption aborted" not in text:
-                assert False, f"Unexpected warning after music volume change: {log['text']}"
+                assert (
+                    False
+                ), f"Unexpected warning after music volume change: {log['text']}"
 
     except Exception as e:
         print(f"Test: 'test_audio_flow' failed: {str(e)}")

--- a/tests/audio_flow_test.py
+++ b/tests/audio_flow_test.py
@@ -144,9 +144,12 @@ def test_audio_flow(page: Page) -> None:
         page.evaluate("window.audioPressed([])")
 
         page.wait_for_function(
-            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'block'",
+            "() => window.getComputedStyle("
+            "document.getElementById('master-slider')"
+            ").display === 'block'",
             timeout=TEST_TIMEOUT,
         )
+        
         wait_for_console_log(
             lambda text: "audio button pressed" in text,
             start_idx=pre_change_log_count,

--- a/tests/audio_flow_test.py
+++ b/tests/audio_flow_test.py
@@ -305,9 +305,9 @@ def test_audio_flow(page: Page) -> None:
         for log in new_logs:
             text = log["text"].lower()
             if "warning" in text and "encryption aborted" not in text:
-                assert (
-                    False
-                ), f"Unexpected warning after music volume change: {log['text']}"
+                raise AssertionError(
+                    f"Unexpected warning after music volume change: {log['text']}"
+                )
 
     except Exception as e:
         print(f"Test: 'test_audio_flow' failed: {str(e)}")

--- a/tests/audio_flow_test.py
+++ b/tests/audio_flow_test.py
@@ -231,11 +231,18 @@ def test_audio_flow(page: Page) -> None:
         ), "Rotors value changed unexpectedly under Master mute"
 
         # Unmute Master for next tests
+        pre_change_log_count = len(logs)
         page.wait_for_function(
             "() => typeof window.toggleMuteMaster !== 'undefined'",
             timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.toggleMuteMaster([1])")
+        wait_for_console_log(
+            logs,
+            lambda text: "master mute button toggled to: true" in text,
+            pre_change_log_count,
+            page,
+        )
 
         # WARN-02: SFX muted → attempt weapon adjust
         page.wait_for_function(
@@ -280,11 +287,18 @@ def test_audio_flow(page: Page) -> None:
         ), "Rotors value changed unexpectedly under SFX mute"
 
         # Unmute SFX
+        pre_change_log_count = len(logs)
         page.wait_for_function(
             "() => typeof window.toggleMuteSfx !== 'undefined'",
             timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.toggleMuteSfx([1])")
+        wait_for_console_log(
+            logs,
+            lambda text: "sfx mute button toggled to: true" in text,
+            pre_change_log_count,
+            page,
+        )
 
         # WARN-03: Master unmuted → adjust sub-volume (Music)
         pre_change_log_count = len(logs)

--- a/tests/audio_flow_test.py
+++ b/tests/audio_flow_test.py
@@ -2,14 +2,13 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # tests/audio_flow_test.py
 """
-Warning Popups & Constraints Test Suite (Playwright + UI Automation with DOM Overlays)
-===================================================================================
+Warning Popups & Constraints Test Suite (Playwright + UI Automation Overlay)
+=============================================================================
 
 Overview
 --------
-E2E tests for WARN-01 to WARN-03: Validate warning popups when adjusting volumes with mutes enabled.
-
-Navigates to audio menu, adjusts sliders/mutes, verifies states, logs, and popups via console logs.
+E2E tests for WARN-01 to WARN-03: Validate warning popups when adjusting
+volumes with mutes enabled.
 
 Prerequisites
 -------------
@@ -28,7 +27,7 @@ v8_coverage_audio_flow_test.json, artifacts/test_audio_failure_*.png/txt
 import json
 import os
 import time
-from typing import Any, Callable
+from typing import Any
 
 import pytest
 from playwright.sync_api import Page, expect
@@ -40,7 +39,8 @@ from tests.test_utils import DEFAULT_TIMEOUT, TEST_TIMEOUT, wait_for_console_log
 def test_audio_flow(page: Page) -> None:
     """
     Main test for warning popups and constraints using DOM overlays.
-    Implements WARN-01 to WARN-03: Mute/adjust, verify unchanged values, warning logs.
+
+    Implements WARN-01 to WARN-03: Mute/adjust, verify unchanged values, warnings.
     """
     logs: list[dict[str, str]] = []
     cdp_session = None
@@ -83,17 +83,20 @@ def test_audio_flow(page: Page) -> None:
 
         # Open options
         page.wait_for_function(
-            "() => typeof window.optionsPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.optionsPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.optionsPressed([])")
 
         # Go to Advanced settings
         page.wait_for_function(
-            "() => typeof window.advancedPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.advancedPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.advancedPressed([])")
         page.wait_for_function(
-            "() => typeof window.changeLogLevel !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.changeLogLevel !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
 
         page.wait_for_function(
@@ -106,8 +109,10 @@ def test_audio_flow(page: Page) -> None:
         pre_change_log_count = len(logs)
         page.evaluate("window.changeLogLevel([0])")
         wait_for_console_log(
+            logs,
             lambda text: "log level changed to: debug" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
 
         assert page.evaluate(
@@ -124,7 +129,8 @@ def test_audio_flow(page: Page) -> None:
         # Open audio
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.audioPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.audioPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.audioPressed([])")
 
@@ -136,8 +142,10 @@ def test_audio_flow(page: Page) -> None:
         )
 
         wait_for_console_log(
+            logs,
             lambda text: "audio button pressed" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
 
         # Get initial values
@@ -155,24 +163,30 @@ def test_audio_flow(page: Page) -> None:
         # WARN-01: Master muted → attempt sub-volume adjust (SFX)
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.toggleMuteMaster !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteMaster !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.toggleMuteMaster([0])")  # Mute
         wait_for_console_log(
+            logs,
             lambda text: "master is muted" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
 
         # Change SFX Volume when Master is muted
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.changeSfxVolume !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.changeSfxVolume !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.changeSfxVolume([0])")
         wait_for_console_log(
+            logs,
             lambda text: "master muted, cannot adjust sub-volume" in text
             or "warning dialog" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
         assert (
             page.evaluate("document.getElementById('sfx-slider').value") == initial_sfx
@@ -186,9 +200,11 @@ def test_audio_flow(page: Page) -> None:
         )
         page.evaluate("window.changeMusicVolume([0.3])")
         wait_for_console_log(
+            logs,
             lambda text: "master muted, cannot adjust sub-volume" in text
             or "warning dialog" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
         assert (
             page.evaluate("document.getElementById('music-slider').value")
@@ -203,9 +219,11 @@ def test_audio_flow(page: Page) -> None:
         )
         page.evaluate("window.changeRotorsVolume([0.4])")
         wait_for_console_log(
+            logs,
             lambda text: "master muted, cannot adjust sub-volume" in text
             or "warning dialog" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
         assert (
             page.evaluate("document.getElementById('rotors-slider').value")
@@ -214,13 +232,15 @@ def test_audio_flow(page: Page) -> None:
 
         # Unmute Master for next tests
         page.wait_for_function(
-            "() => typeof window.toggleMuteMaster !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteMaster !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.toggleMuteMaster([1])")
 
         # WARN-02: SFX muted → attempt weapon adjust
         page.wait_for_function(
-            "() => typeof window.toggleMuteSfx !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteSfx !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.toggleMuteSfx([0])")  # Mute
 
@@ -231,8 +251,11 @@ def test_audio_flow(page: Page) -> None:
         )
         page.evaluate("window.changeWeaponVolume([0])")
         wait_for_console_log(
-            lambda text: "sfx muted, cannot adjust" in text or "warning dialog" in text,
-            start_idx=pre_change_log_count,
+            logs,
+            lambda text: "sfx muted, cannot adjust" in text
+            or "warning dialog" in text,
+            pre_change_log_count,
+            page,
         )
         assert (
             page.evaluate("document.getElementById('weapon-slider').value")
@@ -247,8 +270,11 @@ def test_audio_flow(page: Page) -> None:
         )
         page.evaluate("window.changeRotorsVolume([0.5])")
         wait_for_console_log(
-            lambda text: "sfx muted, cannot adjust" in text or "warning dialog" in text,
-            start_idx=pre_change_log_count,
+            logs,
+            lambda text: "sfx muted, cannot adjust" in text
+            or "warning dialog" in text,
+            pre_change_log_count,
+            page,
         )
         assert (
             page.evaluate("document.getElementById('rotors-slider').value")
@@ -257,7 +283,8 @@ def test_audio_flow(page: Page) -> None:
 
         # Unmute SFX
         page.wait_for_function(
-            "() => typeof window.toggleMuteSfx !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteSfx !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.toggleMuteSfx([1])")
 
@@ -288,7 +315,9 @@ def test_audio_flow(page: Page) -> None:
         print(f"Test: 'test_audio_flow' failed: {str(e)}")
         os.makedirs("artifacts", exist_ok=True)
         timestamp: int = int(time.time())
-        page.screenshot(path=f"artifacts/test_audio_failure_screenshot_{timestamp}.png")
+        page.screenshot(
+            path=f"artifacts/test_audio_failure_screenshot_{timestamp}.png"
+        )
         log_file: str = f"artifacts/test_audio_failure_console_logs_{timestamp}.txt"
         with open(log_file, "w") as f:
             for log in logs:

--- a/tests/audio_flow_test.py
+++ b/tests/audio_flow_test.py
@@ -33,8 +33,7 @@ from typing import Any, Callable
 import pytest
 from playwright.sync_api import Page, expect
 
-DEFAULT_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "30000"))
-TEST_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "5000"))
+from tests.test_utils import DEFAULT_TIMEOUT, TEST_TIMEOUT, wait_for_console_log
 
 
 @pytest.mark.record_har
@@ -57,20 +56,6 @@ def test_audio_flow(page: Page) -> None:
         logs.append({"type": msg.type, "text": msg.text})
 
     page.on("console", on_console)
-
-    def wait_for_console_log(
-        predicate: Callable[[str], bool], start_idx: int, timeout_ms: int = TEST_TIMEOUT
-    ) -> None:
-        """Helper to poll until a matching console log arrives or timeout expires."""
-        start_time = time.time()
-        while (time.time() - start_time) * 1000 < timeout_ms:
-            if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
-                return
-            page.wait_for_timeout(50)  # Micro-poll for event loop progression
-        pytest.fail(
-            "Timed out waiting for expected console log matching "
-            f"predicate after {timeout_ms}ms"
-        )
 
     try:
         # Start CDP session for V8 JS coverage

--- a/tests/audio_flow_test.py
+++ b/tests/audio_flow_test.py
@@ -252,8 +252,7 @@ def test_audio_flow(page: Page) -> None:
         page.evaluate("window.changeWeaponVolume([0])")
         wait_for_console_log(
             logs,
-            lambda text: "sfx muted, cannot adjust" in text
-            or "warning dialog" in text,
+            lambda text: "sfx muted, cannot adjust" in text or "warning dialog" in text,
             pre_change_log_count,
             page,
         )
@@ -271,8 +270,7 @@ def test_audio_flow(page: Page) -> None:
         page.evaluate("window.changeRotorsVolume([0.5])")
         wait_for_console_log(
             logs,
-            lambda text: "sfx muted, cannot adjust" in text
-            or "warning dialog" in text,
+            lambda text: "sfx muted, cannot adjust" in text or "warning dialog" in text,
             pre_change_log_count,
             page,
         )
@@ -315,9 +313,7 @@ def test_audio_flow(page: Page) -> None:
         print(f"Test: 'test_audio_flow' failed: {str(e)}")
         os.makedirs("artifacts", exist_ok=True)
         timestamp: int = int(time.time())
-        page.screenshot(
-            path=f"artifacts/test_audio_failure_screenshot_{timestamp}.png"
-        )
+        page.screenshot(path=f"artifacts/test_audio_failure_screenshot_{timestamp}.png")
         log_file: str = f"artifacts/test_audio_failure_console_logs_{timestamp}.txt"
         with open(log_file, "w") as f:
             for log in logs:

--- a/tests/back_flow_test.py
+++ b/tests/back_flow_test.py
@@ -65,7 +65,7 @@ def test_back_flow(page: Page) -> None:
     page.on("console", on_console)
 
     def wait_for_console_log(
-            predicate: Callable[[str], bool], start_idx: int, timeout_ms: int = TEST_TIMEOUT
+        predicate: Callable[[str], bool], start_idx: int, timeout_ms: int = TEST_TIMEOUT
     ) -> None:
         """
         Helper to poll until a matching console log arrives or timeout expires.
@@ -75,7 +75,9 @@ def test_back_flow(page: Page) -> None:
             if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
                 return
             page.wait_for_timeout(50)  # Micro-poll for event loop progression
-        pytest.fail(f"Timed out waiting for expected console log matching predicate after {timeout_ms}ms")
+        pytest.fail(
+            f"Timed out waiting for expected console log matching predicate after {timeout_ms}ms"
+        )
 
     try:
         # Start CDP session for V8 JS coverage (workaround for Python Playwright lacking native coverage API)
@@ -91,7 +93,9 @@ def test_back_flow(page: Page) -> None:
             timeout=DEFAULT_TIMEOUT,
         )
         # 1. Wait deterministically for Godot engine initialization
-        page.wait_for_function("() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT)
+        page.wait_for_function(
+            "() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT
+        )
 
         # Verify canvas
         canvas = page.locator("canvas")
@@ -139,7 +143,8 @@ def test_back_flow(page: Page) -> None:
             "#advanced-back-button", state="visible", timeout=TEST_TIMEOUT
         )
         page.wait_for_function(
-            "() => typeof window.advancedBackPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.advancedBackPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.advancedBackPressed([])")
 
@@ -213,13 +218,15 @@ def test_back_flow(page: Page) -> None:
             timeout=TEST_TIMEOUT,
         )
         assert (
-                page.evaluate("document.getElementById('master-slider').value")
-                == initial_master
+            page.evaluate("document.getElementById('master-slider').value")
+            == initial_master
         ), "State mutated without changes"
 
         # Re-enter audio via page reload
         page.reload(wait_until="networkidle")
-        page.wait_for_function("() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT)
+        page.wait_for_function(
+            "() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT
+        )
 
         # Navigate to options menu
         page.wait_for_selector("#options-button", state="visible", timeout=TEST_TIMEOUT)
@@ -241,7 +248,8 @@ def test_back_flow(page: Page) -> None:
 
         # BACK-03: Back after slider changes
         page.wait_for_function(
-            "() => typeof window.changeMusicVolume !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.changeMusicVolume !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.changeMusicVolume([0.4])")
         page.wait_for_function(
@@ -262,7 +270,7 @@ def test_back_flow(page: Page) -> None:
             timeout=TEST_TIMEOUT,
         )
         assert (
-                page.evaluate("document.getElementById('music-slider').value") == "0.4"
+            page.evaluate("document.getElementById('music-slider').value") == "0.4"
         ), "Changes did not persist after back"
 
         # BACK-04: Back from mid-interaction
@@ -291,7 +299,7 @@ def test_back_flow(page: Page) -> None:
         timestamp: int = int(time.time())
         page.screenshot(path=f"artifacts/test_back_failure_screenshot_{timestamp}.png")
         with open(
-                f"artifacts/test_back_failure_console_logs_{timestamp}.txt", "w"
+            f"artifacts/test_back_failure_console_logs_{timestamp}.txt", "w"
         ) as f:
             for log in logs:
                 f.write(f"[{log['type']}] {log['text']}\n")

--- a/tests/back_flow_test.py
+++ b/tests/back_flow_test.py
@@ -28,11 +28,13 @@ v8_coverage_back_flow_test.json, artifacts/test_back_failure_*.png/txt
 import json
 import os
 import time
+from typing import Any, Callable
 
-from playwright.sync_api import Page
+import pytest
+from playwright.sync_api import Page, expect
 
 # Configuration for stability in different environments
-# Default to 5000ms, but allow CI to override via environment variable
+# Default to 30000ms, but allow CI to override via environment variable
 DEFAULT_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "30000"))
 TEST_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "10000"))
 
@@ -50,7 +52,7 @@ def test_back_flow(page: Page) -> None:
     logs: list[dict[str, str]] = []
     cdp_session = None
 
-    def on_console(msg) -> None:
+    def on_console(msg: Any) -> None:
         """
         Console message handler to capture logs.
 
@@ -61,6 +63,20 @@ def test_back_flow(page: Page) -> None:
         logs.append({"type": msg.type, "text": msg.text})
 
     page.on("console", on_console)
+
+    def wait_for_console_log(
+            predicate: Callable[[str], bool], start_idx: int, timeout_ms: int = TEST_TIMEOUT
+    ) -> None:
+        """
+        Helper to poll until a matching console log arrives or timeout expires.
+        """
+        start_time = time.time()
+        while (time.time() - start_time) * 1000 < timeout_ms:
+            if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
+                return
+            page.wait_for_timeout(50)  # Micro-poll for event loop progression
+        pytest.fail(f"Timed out waiting for expected console log matching predicate after {timeout_ms}ms")
+
     try:
         # Start CDP session for V8 JS coverage (workaround for Python Playwright lacking native coverage API)
         cdp_session = page.context.new_cdp_session(page)
@@ -74,13 +90,12 @@ def test_back_flow(page: Page) -> None:
             wait_until="networkidle",
             timeout=DEFAULT_TIMEOUT,
         )
-        # 1. Wait for the engine to actually start the splash scene
-        page.wait_for_timeout(TEST_TIMEOUT)
-        page.wait_for_function("() => window.godotInitialized", timeout=DEFAULT_TIMEOUT)
+        # 1. Wait deterministically for Godot engine initialization
+        page.wait_for_function("() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT)
 
         # Verify canvas
         canvas = page.locator("canvas")
-        page.wait_for_selector("canvas", state="visible", timeout=DEFAULT_TIMEOUT)
+        expect(canvas).to_be_visible(timeout=DEFAULT_TIMEOUT)
         box: dict[str, float] | None = canvas.bounding_box()
         assert box is not None, "Canvas not found"
         assert "SkyLockAssault" in page.title(), "Title not found"
@@ -88,7 +103,7 @@ def test_back_flow(page: Page) -> None:
         # Navigate to options menu
         page.wait_for_selector("#options-button", state="visible", timeout=TEST_TIMEOUT)
         page.wait_for_function(
-            "window.optionsPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.optionsPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.optionsPressed([])")
 
@@ -97,26 +112,23 @@ def test_back_flow(page: Page) -> None:
             "#advanced-button", state="visible", timeout=TEST_TIMEOUT
         )
         page.wait_for_function(
-            "window.advancedPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.advancedPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.advancedPressed([])")
         page.wait_for_function(
-            "window.changeLogLevel !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.changeLogLevel !== 'undefined'", timeout=TEST_TIMEOUT
         )
-        advanced_display: str = page.evaluate(
-            "window.getComputedStyle(document.getElementById('log-level-select')).display"
+        page.wait_for_function(
+            "() => window.getComputedStyle(document.getElementById('log-level-select')).display === 'block'",
+            timeout=TEST_TIMEOUT,
         )
-        assert (
-            advanced_display == "block"
-        ), "Advanced menu not loaded (selected log level not displayed)"
 
         # Set log level DEBUG
         pre_change_log_count = len(logs)
         page.evaluate("window.changeLogLevel([0])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        new_logs = logs[pre_change_log_count:]
-        assert any(
-            "log level changed to: debug" in log["text"].lower() for log in new_logs
+        wait_for_console_log(
+            lambda text: "log level changed to: debug" in text,
+            start_idx=pre_change_log_count,
         )
         assert page.evaluate(
             "document.getElementById('audio-button') !== null"
@@ -127,9 +139,10 @@ def test_back_flow(page: Page) -> None:
             "#advanced-back-button", state="visible", timeout=TEST_TIMEOUT
         )
         page.wait_for_function(
-            "window.advancedBackPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.advancedBackPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.advancedBackPressed([])")
+
         # Navigate to audio sub-menu
         page.wait_for_selector("#audio-button", state="visible", timeout=TEST_TIMEOUT)
         assert page.evaluate(
@@ -137,133 +150,136 @@ def test_back_flow(page: Page) -> None:
         ), "Audio button not found/displayed"
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "window.audioPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.audioPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.audioPressed([])")
-        page.wait_for_timeout(TEST_TIMEOUT)  # Wait for audio scene load and JS eval
-        audio_display: str = page.evaluate(
-            "window.getComputedStyle(document.getElementById('master-slider')).display"
+
+        # Wait deterministically for audio menu display
+        page.wait_for_function(
+            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'block'",
+            timeout=TEST_TIMEOUT,
         )
-        assert (
-            audio_display == "block"
-        ), "Audio menu not loaded (master-slider not displayed)"
-        new_logs = logs[pre_change_log_count:]
-        assert any(
-            "audio button pressed." in log["text"].lower() for log in new_logs
-        ), "Audio navigation log not found"
+        wait_for_console_log(
+            lambda text: "audio button pressed." in text,
+            start_idx=pre_change_log_count,
+        )
 
         # BACK-01: Back returns to parent menu
-        # Preconditions: In Audio Settings
-        # Steps: Press Back
-        # Expected: Options menu visible
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "window.audioBackPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.audioBackPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.audioBackPressed([])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        options_display: str = page.evaluate(
-            "window.getComputedStyle(document.getElementById('gameplay-button')).display"
+
+        page.wait_for_function(
+            "() => window.getComputedStyle(document.getElementById('gameplay-button')).display === 'block'",
+            timeout=TEST_TIMEOUT,
         )
-        assert options_display == "block", "Did not return to options menu"
-        audio_display_after: str = page.evaluate(
-            "window.getComputedStyle(document.getElementById('master-slider')).display"
+        page.wait_for_function(
+            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'none'",
+            timeout=TEST_TIMEOUT,
         )
-        assert audio_display_after == "none", "Audio menu still visible after back"
-        new_logs = logs[pre_change_log_count:]
-        assert any(
-            "audio settings: back button pressed" in log["text"].lower()
-            for log in new_logs
-        ), "Back log not found"
+        wait_for_console_log(
+            lambda text: "audio settings: back button pressed" in text,
+            start_idx=pre_change_log_count,
+        )
 
         # Re-enter audio for next tests
         page.wait_for_selector("#audio-button", state="visible", timeout=TEST_TIMEOUT)
         page.wait_for_function(
-            "window.audioPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.audioPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.audioPressed([0])")
-        page.wait_for_timeout(TEST_TIMEOUT)
+        page.wait_for_function(
+            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'block'",
+            timeout=TEST_TIMEOUT,
+        )
 
         # BACK-02: Back without changes
-        # Preconditions: No modification
-        # Steps: Press Back
-        # Expected: Back to Options; no state mutation
         initial_master: str = page.evaluate(
             "document.getElementById('master-slider').value"
         )
         page.wait_for_function(
-            "window.audioBackPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.audioBackPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.audioBackPressed([])")
         page.wait_for_selector("#audio-button", state="visible", timeout=TEST_TIMEOUT)
         page.wait_for_function(
-            "window.audioPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.audioPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.audioPressed([0])")
-        page.wait_for_timeout(TEST_TIMEOUT)
+        page.wait_for_function(
+            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'block'",
+            timeout=TEST_TIMEOUT,
+        )
         assert (
-            page.evaluate("document.getElementById('master-slider').value")
-            == initial_master
+                page.evaluate("document.getElementById('master-slider').value")
+                == initial_master
         ), "State mutated without changes"
 
-        # Re-enter audio
-        page.reload()
-        page.wait_for_timeout(DEFAULT_TIMEOUT)
-        page.wait_for_function("() => window.godotInitialized", timeout=TEST_TIMEOUT)
+        # Re-enter audio via page reload
+        page.reload(wait_until="networkidle")
+        page.wait_for_function("() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT)
+
         # Navigate to options menu
         page.wait_for_selector("#options-button", state="visible", timeout=TEST_TIMEOUT)
         page.wait_for_function(
-            "window.optionsPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.optionsPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.optionsPressed([])")
+
         # Navigate to audio menu
         page.wait_for_selector("#audio-button", state="visible", timeout=TEST_TIMEOUT)
         page.wait_for_function(
-            "window.audioPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.audioPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.audioPressed([0])")
-        page.wait_for_timeout(TEST_TIMEOUT)
+        page.wait_for_function(
+            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'block'",
+            timeout=TEST_TIMEOUT,
+        )
 
         # BACK-03: Back after slider changes
-        # Preconditions: Sliders adjusted but not Reset
-        # Steps: Press Back
-        # Expected: Return; previous changes persist until Reset
         page.wait_for_function(
-            "window.changeMusicVolume !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.changeMusicVolume !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.changeMusicVolume([0.4])")
-        page.wait_for_timeout(TEST_TIMEOUT)
         page.wait_for_function(
-            "window.audioBackPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => document.getElementById('music-slider').value === '0.4'",
+            timeout=TEST_TIMEOUT,
+        )
+        page.wait_for_function(
+            "() => typeof window.audioBackPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.audioBackPressed([])")
         page.wait_for_selector("#audio-button", state="visible", timeout=TEST_TIMEOUT)
         page.wait_for_function(
-            "window.audioPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.audioPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.audioPressed([0])")
-        page.wait_for_timeout(TEST_TIMEOUT)
+        page.wait_for_function(
+            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'block'",
+            timeout=TEST_TIMEOUT,
+        )
         assert (
-            page.evaluate("document.getElementById('music-slider').value") == "0.4"
+                page.evaluate("document.getElementById('music-slider').value") == "0.4"
         ), "Changes did not persist after back"
 
         # BACK-04: Back from mid-interaction
-        # Preconditions: Slider being dragged
-        # Steps: Trigger Back
-        # Expected: Navigation ok, no JS exceptions
-        # Simulate mid-drag by setting value without full change event, then back
         pre_change_log_count = len(logs)
         page.evaluate("""
             const slider = document.getElementById('sfx-slider');
             slider.value = 0.6;
             slider.dispatchEvent(new Event('input'));  // Mid-drag
         """)
-        page.wait_for_timeout(TEST_TIMEOUT)
         page.wait_for_function(
-            "window.audioBackPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.audioBackPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.audioBackPressed([])")
-        page.wait_for_timeout(TEST_TIMEOUT)
+        page.wait_for_function(
+            "() => window.getComputedStyle(document.getElementById('gameplay-button')).display === 'block'",
+            timeout=TEST_TIMEOUT,
+        )
         new_logs = logs[pre_change_log_count:]
         assert not any(
             "error" in log["text"].lower() for log in new_logs
@@ -275,7 +291,7 @@ def test_back_flow(page: Page) -> None:
         timestamp: int = int(time.time())
         page.screenshot(path=f"artifacts/test_back_failure_screenshot_{timestamp}.png")
         with open(
-            f"artifacts/test_back_failure_console_logs_{timestamp}.txt", "w"
+                f"artifacts/test_back_failure_console_logs_{timestamp}.txt", "w"
         ) as f:
             for log in logs:
                 f.write(f"[{log['type']}] {log['text']}\n")

--- a/tests/back_flow_test.py
+++ b/tests/back_flow_test.py
@@ -7,7 +7,9 @@ Back Navigation Test Suite (Playwright + UI Automation with DOM Overlays)
 
 Overview
 --------
-E2E tests for BACK-01 to BACK-04: Validate back button behavior from audio menu, including return to options, no state mutation without changes, persistence of changes, and handling mid-interaction.
+E2E tests for BACK-01 to BACK-04: Validate back button behavior from audio menu,
+including return to options, no state mutation without changes, persistence of changes,
+and handling mid-interaction.
 
 Navigates to audio menu, performs actions, backs out, verifies states/logs.
 
@@ -34,7 +36,6 @@ import pytest
 from playwright.sync_api import Page, expect
 
 # Configuration for stability in different environments
-# Default to 30000ms, but allow CI to override via environment variable
 DEFAULT_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "30000"))
 TEST_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "10000"))
 
@@ -43,7 +44,7 @@ def test_back_flow(page: Page) -> None:
     """
     Main test suite for back navigation using DOM overlays.
 
-    Implements BACK-01 to BACK-04: Back from audio, verify return, state persistence, no exceptions.
+    Implements BACK-01 to BACK-04: Back from audio, verify return, state persistence.
 
     :param page: The Playwright page object.
     :type page: Page
@@ -65,22 +66,23 @@ def test_back_flow(page: Page) -> None:
     page.on("console", on_console)
 
     def wait_for_console_log(
-        predicate: Callable[[str], bool], start_idx: int, timeout_ms: int = TEST_TIMEOUT
+        predicate: Callable[[str], bool],
+        start_idx: int,
+        timeout_ms: int = TEST_TIMEOUT,
     ) -> None:
-        """
-        Helper to poll until a matching console log arrives or timeout expires.
-        """
+        """Helper to poll until a matching console log arrives or timeout expires."""
         start_time = time.time()
         while (time.time() - start_time) * 1000 < timeout_ms:
             if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
                 return
             page.wait_for_timeout(50)  # Micro-poll for event loop progression
         pytest.fail(
-            f"Timed out waiting for expected console log matching predicate after {timeout_ms}ms"
+            "Timed out waiting for expected console log matching "
+            f"predicate after {timeout_ms}ms"
         )
 
     try:
-        # Start CDP session for V8 JS coverage (workaround for Python Playwright lacking native coverage API)
+        # Start CDP session for V8 JS coverage
         cdp_session = page.context.new_cdp_session(page)
         cdp_session.send("Profiler.enable")
         cdp_session.send(
@@ -123,7 +125,9 @@ def test_back_flow(page: Page) -> None:
             "() => typeof window.changeLogLevel !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.wait_for_function(
-            "() => window.getComputedStyle(document.getElementById('log-level-select')).display === 'block'",
+            "() => window.getComputedStyle("
+            "document.getElementById('log-level-select')"
+            ").display === 'block'",
             timeout=TEST_TIMEOUT,
         )
 
@@ -161,7 +165,9 @@ def test_back_flow(page: Page) -> None:
 
         # Wait deterministically for audio menu display
         page.wait_for_function(
-            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'block'",
+            "() => window.getComputedStyle("
+            "document.getElementById('master-slider')"
+            ").display === 'block'",
             timeout=TEST_TIMEOUT,
         )
         wait_for_console_log(
@@ -177,11 +183,15 @@ def test_back_flow(page: Page) -> None:
         page.evaluate("window.audioBackPressed([])")
 
         page.wait_for_function(
-            "() => window.getComputedStyle(document.getElementById('gameplay-button')).display === 'block'",
+            "() => window.getComputedStyle("
+            "document.getElementById('gameplay-button')"
+            ").display === 'block'",
             timeout=TEST_TIMEOUT,
         )
         page.wait_for_function(
-            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'none'",
+            "() => window.getComputedStyle("
+            "document.getElementById('master-slider')"
+            ").display === 'none'",
             timeout=TEST_TIMEOUT,
         )
         wait_for_console_log(
@@ -196,7 +206,9 @@ def test_back_flow(page: Page) -> None:
         )
         page.evaluate("window.audioPressed([0])")
         page.wait_for_function(
-            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'block'",
+            "() => window.getComputedStyle("
+            "document.getElementById('master-slider')"
+            ").display === 'block'",
             timeout=TEST_TIMEOUT,
         )
 
@@ -214,7 +226,9 @@ def test_back_flow(page: Page) -> None:
         )
         page.evaluate("window.audioPressed([0])")
         page.wait_for_function(
-            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'block'",
+            "() => window.getComputedStyle("
+            "document.getElementById('master-slider')"
+            ").display === 'block'",
             timeout=TEST_TIMEOUT,
         )
         assert (
@@ -242,7 +256,9 @@ def test_back_flow(page: Page) -> None:
         )
         page.evaluate("window.audioPressed([0])")
         page.wait_for_function(
-            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'block'",
+            "() => window.getComputedStyle("
+            "document.getElementById('master-slider')"
+            ").display === 'block'",
             timeout=TEST_TIMEOUT,
         )
 
@@ -266,7 +282,9 @@ def test_back_flow(page: Page) -> None:
         )
         page.evaluate("window.audioPressed([0])")
         page.wait_for_function(
-            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'block'",
+            "() => window.getComputedStyle("
+            "document.getElementById('master-slider')"
+            ").display === 'block'",
             timeout=TEST_TIMEOUT,
         )
         assert (
@@ -285,7 +303,9 @@ def test_back_flow(page: Page) -> None:
         )
         page.evaluate("window.audioBackPressed([])")
         page.wait_for_function(
-            "() => window.getComputedStyle(document.getElementById('gameplay-button')).display === 'block'",
+            "() => window.getComputedStyle("
+            "document.getElementById('gameplay-button')"
+            ").display === 'block'",
             timeout=TEST_TIMEOUT,
         )
         new_logs = logs[pre_change_log_count:]

--- a/tests/back_flow_test.py
+++ b/tests/back_flow_test.py
@@ -36,8 +36,7 @@ import pytest
 from playwright.sync_api import Page, expect
 
 # Configuration for stability in different environments
-DEFAULT_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "30000"))
-TEST_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "10000"))
+from tests.test_utils import DEFAULT_TIMEOUT, TEST_TIMEOUT, wait_for_console_log
 
 
 def test_back_flow(page: Page) -> None:
@@ -64,22 +63,6 @@ def test_back_flow(page: Page) -> None:
         logs.append({"type": msg.type, "text": msg.text})
 
     page.on("console", on_console)
-
-    def wait_for_console_log(
-        predicate: Callable[[str], bool],
-        start_idx: int,
-        timeout_ms: int = TEST_TIMEOUT,
-    ) -> None:
-        """Helper to poll until a matching console log arrives or timeout expires."""
-        start_time = time.time()
-        while (time.time() - start_time) * 1000 < timeout_ms:
-            if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
-                return
-            page.wait_for_timeout(50)  # Micro-poll for event loop progression
-        pytest.fail(
-            "Timed out waiting for expected console log matching "
-            f"predicate after {timeout_ms}ms"
-        )
 
     try:
         # Start CDP session for V8 JS coverage

--- a/tests/back_flow_test.py
+++ b/tests/back_flow_test.py
@@ -89,9 +89,7 @@ def test_back_flow(page: Page) -> None:
         assert "SkyLockAssault" in page.title(), "Title not found"
 
         # Navigate to options menu
-        page.wait_for_selector(
-            "#options-button", state="visible", timeout=TEST_TIMEOUT
-        )
+        page.wait_for_selector("#options-button", state="visible", timeout=TEST_TIMEOUT)
         page.wait_for_function(
             "() => typeof window.optionsPressed !== 'undefined'",
             timeout=TEST_TIMEOUT,
@@ -142,9 +140,7 @@ def test_back_flow(page: Page) -> None:
         page.evaluate("window.advancedBackPressed([])")
 
         # Navigate to audio sub-menu
-        page.wait_for_selector(
-            "#audio-button", state="visible", timeout=TEST_TIMEOUT
-        )
+        page.wait_for_selector("#audio-button", state="visible", timeout=TEST_TIMEOUT)
         assert page.evaluate(
             "document.getElementById('audio-button') !== null"
         ), "Audio button not found/displayed"
@@ -197,9 +193,7 @@ def test_back_flow(page: Page) -> None:
         )
 
         # Re-enter audio for next tests
-        page.wait_for_selector(
-            "#audio-button", state="visible", timeout=TEST_TIMEOUT
-        )
+        page.wait_for_selector("#audio-button", state="visible", timeout=TEST_TIMEOUT)
         page.wait_for_function(
             "() => typeof window.audioPressed !== 'undefined'",
             timeout=TEST_TIMEOUT,
@@ -221,9 +215,7 @@ def test_back_flow(page: Page) -> None:
             timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.audioBackPressed([])")
-        page.wait_for_selector(
-            "#audio-button", state="visible", timeout=TEST_TIMEOUT
-        )
+        page.wait_for_selector("#audio-button", state="visible", timeout=TEST_TIMEOUT)
         page.wait_for_function(
             "() => typeof window.audioPressed !== 'undefined'",
             timeout=TEST_TIMEOUT,
@@ -247,9 +239,7 @@ def test_back_flow(page: Page) -> None:
         )
 
         # Navigate to options menu
-        page.wait_for_selector(
-            "#options-button", state="visible", timeout=TEST_TIMEOUT
-        )
+        page.wait_for_selector("#options-button", state="visible", timeout=TEST_TIMEOUT)
         page.wait_for_function(
             "() => typeof window.optionsPressed !== 'undefined'",
             timeout=TEST_TIMEOUT,
@@ -257,9 +247,7 @@ def test_back_flow(page: Page) -> None:
         page.evaluate("window.optionsPressed([])")
 
         # Navigate to audio menu
-        page.wait_for_selector(
-            "#audio-button", state="visible", timeout=TEST_TIMEOUT
-        )
+        page.wait_for_selector("#audio-button", state="visible", timeout=TEST_TIMEOUT)
         page.wait_for_function(
             "() => typeof window.audioPressed !== 'undefined'",
             timeout=TEST_TIMEOUT,
@@ -287,9 +275,7 @@ def test_back_flow(page: Page) -> None:
             timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.audioBackPressed([])")
-        page.wait_for_selector(
-            "#audio-button", state="visible", timeout=TEST_TIMEOUT
-        )
+        page.wait_for_selector("#audio-button", state="visible", timeout=TEST_TIMEOUT)
         page.wait_for_function(
             "() => typeof window.audioPressed !== 'undefined'",
             timeout=TEST_TIMEOUT,
@@ -332,9 +318,7 @@ def test_back_flow(page: Page) -> None:
         print(f"Test suite failed: {str(e)}")
         os.makedirs("artifacts", exist_ok=True)
         timestamp: int = int(time.time())
-        page.screenshot(
-            path=f"artifacts/test_back_failure_screenshot_{timestamp}.png"
-        )
+        page.screenshot(path=f"artifacts/test_back_failure_screenshot_{timestamp}.png")
         with open(
             f"artifacts/test_back_failure_console_logs_{timestamp}.txt", "w"
         ) as f:

--- a/tests/back_flow_test.py
+++ b/tests/back_flow_test.py
@@ -30,12 +30,11 @@ v8_coverage_back_flow_test.json, artifacts/test_back_failure_*.png/txt
 import json
 import os
 import time
-from typing import Any, Callable
+from typing import Any
 
 import pytest
 from playwright.sync_api import Page, expect
 
-# Configuration for stability in different environments
 from tests.test_utils import DEFAULT_TIMEOUT, TEST_TIMEOUT, wait_for_console_log
 
 
@@ -90,9 +89,12 @@ def test_back_flow(page: Page) -> None:
         assert "SkyLockAssault" in page.title(), "Title not found"
 
         # Navigate to options menu
-        page.wait_for_selector("#options-button", state="visible", timeout=TEST_TIMEOUT)
+        page.wait_for_selector(
+            "#options-button", state="visible", timeout=TEST_TIMEOUT
+        )
         page.wait_for_function(
-            "() => typeof window.optionsPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.optionsPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.optionsPressed([])")
 
@@ -101,11 +103,13 @@ def test_back_flow(page: Page) -> None:
             "#advanced-button", state="visible", timeout=TEST_TIMEOUT
         )
         page.wait_for_function(
-            "() => typeof window.advancedPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.advancedPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.advancedPressed([])")
         page.wait_for_function(
-            "() => typeof window.changeLogLevel !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.changeLogLevel !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.wait_for_function(
             "() => window.getComputedStyle("
@@ -118,8 +122,10 @@ def test_back_flow(page: Page) -> None:
         pre_change_log_count = len(logs)
         page.evaluate("window.changeLogLevel([0])")
         wait_for_console_log(
+            logs,
             lambda text: "log level changed to: debug" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
         assert page.evaluate(
             "document.getElementById('audio-button') !== null"
@@ -136,13 +142,16 @@ def test_back_flow(page: Page) -> None:
         page.evaluate("window.advancedBackPressed([])")
 
         # Navigate to audio sub-menu
-        page.wait_for_selector("#audio-button", state="visible", timeout=TEST_TIMEOUT)
+        page.wait_for_selector(
+            "#audio-button", state="visible", timeout=TEST_TIMEOUT
+        )
         assert page.evaluate(
             "document.getElementById('audio-button') !== null"
         ), "Audio button not found/displayed"
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.audioPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.audioPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.audioPressed([])")
 
@@ -154,14 +163,17 @@ def test_back_flow(page: Page) -> None:
             timeout=TEST_TIMEOUT,
         )
         wait_for_console_log(
+            logs,
             lambda text: "audio button pressed." in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
 
         # BACK-01: Back returns to parent menu
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.audioBackPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.audioBackPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.audioBackPressed([])")
 
@@ -178,14 +190,19 @@ def test_back_flow(page: Page) -> None:
             timeout=TEST_TIMEOUT,
         )
         wait_for_console_log(
+            logs,
             lambda text: "audio settings: back button pressed" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
 
         # Re-enter audio for next tests
-        page.wait_for_selector("#audio-button", state="visible", timeout=TEST_TIMEOUT)
+        page.wait_for_selector(
+            "#audio-button", state="visible", timeout=TEST_TIMEOUT
+        )
         page.wait_for_function(
-            "() => typeof window.audioPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.audioPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.audioPressed([0])")
         page.wait_for_function(
@@ -200,12 +217,16 @@ def test_back_flow(page: Page) -> None:
             "document.getElementById('master-slider').value"
         )
         page.wait_for_function(
-            "() => typeof window.audioBackPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.audioBackPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.audioBackPressed([])")
-        page.wait_for_selector("#audio-button", state="visible", timeout=TEST_TIMEOUT)
+        page.wait_for_selector(
+            "#audio-button", state="visible", timeout=TEST_TIMEOUT
+        )
         page.wait_for_function(
-            "() => typeof window.audioPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.audioPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.audioPressed([0])")
         page.wait_for_function(
@@ -226,16 +247,22 @@ def test_back_flow(page: Page) -> None:
         )
 
         # Navigate to options menu
-        page.wait_for_selector("#options-button", state="visible", timeout=TEST_TIMEOUT)
+        page.wait_for_selector(
+            "#options-button", state="visible", timeout=TEST_TIMEOUT
+        )
         page.wait_for_function(
-            "() => typeof window.optionsPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.optionsPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.optionsPressed([])")
 
         # Navigate to audio menu
-        page.wait_for_selector("#audio-button", state="visible", timeout=TEST_TIMEOUT)
+        page.wait_for_selector(
+            "#audio-button", state="visible", timeout=TEST_TIMEOUT
+        )
         page.wait_for_function(
-            "() => typeof window.audioPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.audioPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.audioPressed([0])")
         page.wait_for_function(
@@ -256,12 +283,16 @@ def test_back_flow(page: Page) -> None:
             timeout=TEST_TIMEOUT,
         )
         page.wait_for_function(
-            "() => typeof window.audioBackPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.audioBackPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.audioBackPressed([])")
-        page.wait_for_selector("#audio-button", state="visible", timeout=TEST_TIMEOUT)
+        page.wait_for_selector(
+            "#audio-button", state="visible", timeout=TEST_TIMEOUT
+        )
         page.wait_for_function(
-            "() => typeof window.audioPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.audioPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.audioPressed([0])")
         page.wait_for_function(
@@ -282,7 +313,8 @@ def test_back_flow(page: Page) -> None:
             slider.dispatchEvent(new Event('input'));  // Mid-drag
         """)
         page.wait_for_function(
-            "() => typeof window.audioBackPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.audioBackPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.audioBackPressed([])")
         page.wait_for_function(
@@ -300,7 +332,9 @@ def test_back_flow(page: Page) -> None:
         print(f"Test suite failed: {str(e)}")
         os.makedirs("artifacts", exist_ok=True)
         timestamp: int = int(time.time())
-        page.screenshot(path=f"artifacts/test_back_failure_screenshot_{timestamp}.png")
+        page.screenshot(
+            path=f"artifacts/test_back_failure_screenshot_{timestamp}.png"
+        )
         with open(
             f"artifacts/test_back_failure_console_logs_{timestamp}.txt", "w"
         ) as f:

--- a/tests/back_flow_test.py
+++ b/tests/back_flow_test.py
@@ -32,7 +32,6 @@ import os
 import time
 from typing import Any
 
-import pytest
 from playwright.sync_api import Page, expect
 
 from tests.test_utils import DEFAULT_TIMEOUT, TEST_TIMEOUT, wait_for_console_log

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,52 +5,54 @@
 Shared pytest fixtures and configs for SkyLockAssault E2E tests.
 """
 
-import pytest
 import re
 from pathlib import Path
-from playwright.sync_api import Page, Playwright
+from typing import Generator
+import pytest
+from playwright.sync_api import Browser, BrowserContext, Page, Playwright
+
+
+@pytest.fixture(scope="session")
+def browser_instance(playwright: Playwright) -> Generator[Browser, None, None]:
+    """
+    Session-scoped Chromium launch fixture to minimize startup overhead across the test suite.
+    """
+    browser = playwright.chromium.launch(
+        headless=True,
+        args=[
+            "--enable-unsafe-swiftshader",
+            "--disable-gpu",
+            "--use-gl=swiftshader",
+        ],
+    )
+    yield browser
+    browser.close()
 
 
 @pytest.fixture(scope="function")
-def page(playwright: Playwright, request) -> Page:
+def page(browser_instance: Browser, request: pytest.FixtureRequest) -> Generator[Page, None, None]:
     """
-    Shared fixture for browser page setup with CDP for coverage.
-    Launches headless Chromium with GPU flags for Godot HTML5/WebGL compatibility.
-
-    :param playwright: The Playwright instance.
-    :param request: Pytest request object (for accessing markers/configs).
-    :return: The configured page object.
+    Function-scoped page fixture providing clean browser context isolation for each test.
     """
-    # Optional: Enable HAR recording if the test is marked with @pytest.mark.record_har
     har_path = None
     if request.node.get_closest_marker("record_har"):
-        # Derive a per-test HAR path from the test nodeid to avoid overwrites
         nodeid = request.node.nodeid
-        # Sanitize nodeid so it's safe as a filename (e.g. replace path separators/param brackets)
         safe_nodeid = re.sub(r"[^A-Za-z0-9._-]+", "_", nodeid)
         artifacts_dir = Path("artifacts")
         artifacts_dir.mkdir(parents=True, exist_ok=True)
         har_path = artifacts_dir / f"{safe_nodeid}.har"
 
-    browser = playwright.chromium.launch(
-        headless=True,  # Change to False for headful debugging (see browser visually)
-        args=[
-            "--enable-unsafe-swiftshader",
-            "--disable-gpu",
-            "--use-gl=swiftshader",
-        ]
-    )
-    context = browser.new_context(
+    context: BrowserContext = browser_instance.new_context(
         viewport={"width": 1280, "height": 720},
-        record_har_path=str(har_path) if har_path else None,  # Network trace for debugging (optional)
+        record_har_path=str(har_path) if har_path else None,
     )
-    page = context.new_page()
+    page: Page = context.new_page()
     yield page
     context.close()
-    browser.close()
 
 
-def pytest_configure(config):
+def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line(
-        "markers", "record_har: Mark tests that should record HAR files for network tracing in Playwright."
+        "markers",
+        "record_har: Mark tests that should record HAR files for network tracing in Playwright.",
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ Shared pytest fixtures and configs for SkyLockAssault E2E tests.
 import re
 from pathlib import Path
 from typing import Generator
+
 import pytest
 from playwright.sync_api import Browser, BrowserContext, Page, Playwright
 
@@ -30,7 +31,9 @@ def browser_instance(playwright: Playwright) -> Generator[Browser, None, None]:
 
 
 @pytest.fixture(scope="function")
-def page(browser_instance: Browser, request: pytest.FixtureRequest) -> Generator[Page, None, None]:
+def page(
+    browser_instance: Browser, request: pytest.FixtureRequest
+) -> Generator[Page, None, None]:
     """
     Function-scoped page fixture providing clean browser context isolation for each test.
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,8 @@ from playwright.sync_api import Browser, BrowserContext, Page, Playwright
 @pytest.fixture(scope="session")
 def browser_instance(playwright: Playwright) -> Generator[Browser, None, None]:
     """
-    Session-scoped Chromium launch fixture to minimize startup overhead across the test suite.
+    Session-scoped Chromium launch fixture to minimize startup
+    overhead across the test suite.
     """
     browser = playwright.chromium.launch(
         headless=True,
@@ -35,7 +36,8 @@ def page(
     browser_instance: Browser, request: pytest.FixtureRequest
 ) -> Generator[Page, None, None]:
     """
-    Function-scoped page fixture providing clean browser context isolation for each test.
+    Function-scoped page fixture providing clean browser context
+    isolation for each test.
     """
     har_path = None
     if request.node.get_closest_marker("record_har"):
@@ -57,5 +59,6 @@ def page(
 def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line(
         "markers",
-        "record_har: Mark tests that should record HAR files for network tracing in Playwright.",
+        "record_har: Mark tests that should record HAR files "
+        "for network tracing in Playwright.",
     )

--- a/tests/difficulty_flow_test.py
+++ b/tests/difficulty_flow_test.py
@@ -70,7 +70,9 @@ def test_difficulty_flow(page: Page) -> None:
     page.on("console", on_console)
 
     def wait_for_console_log(
-        predicate: Callable[[str], bool], start_idx: int, timeout_ms: int = DEFAULT_TIMEOUT
+        predicate: Callable[[str], bool],
+        start_idx: int,
+        timeout_ms: int = DEFAULT_TIMEOUT,
     ) -> None:
         """
         Helper to poll until a matching console log arrives or timeout expires.
@@ -80,7 +82,9 @@ def test_difficulty_flow(page: Page) -> None:
             if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
                 return
             page.wait_for_timeout(50)  # Micro-poll for event loop progression
-        pytest.fail(f"Timed out waiting for expected console log matching predicate after {timeout_ms}ms")
+        pytest.fail(
+            f"Timed out waiting for expected console log matching predicate after {timeout_ms}ms"
+        )
 
     try:
         # Start CDP session for V8 JS coverage
@@ -97,7 +101,9 @@ def test_difficulty_flow(page: Page) -> None:
         )
 
         # 1. Wait deterministically for Godot engine initialization
-        page.wait_for_function("() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT)
+        page.wait_for_function(
+            "() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT
+        )
 
         # Verify canvas and title to ensure game is initialized
         canvas = page.locator("canvas")
@@ -180,7 +186,8 @@ def test_difficulty_flow(page: Page) -> None:
             "#advanced-back-button", state="visible", timeout=TEST_TIMEOUT
         )
         page.wait_for_function(
-            "() => typeof window.advancedBackPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.advancedBackPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.advancedBackPressed([])")
 
@@ -226,7 +233,8 @@ def test_difficulty_flow(page: Page) -> None:
         # Reset gameplay settings back to defaults
         pre_reset_log_count: int = len(logs)
         page.wait_for_function(
-            "() => typeof window.gameplayResetPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.gameplayResetPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.gameplayResetPressed([])")
         wait_for_console_log(
@@ -251,7 +259,8 @@ def test_difficulty_flow(page: Page) -> None:
         # Back to Main menu
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.gameplayBackPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.gameplayBackPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.gameplayBackPressed([])")
         wait_for_console_log(
@@ -329,7 +338,8 @@ def test_difficulty_flow(page: Page) -> None:
 
         start_logs = logs[pre_start_log_count:]
         assert any(
-            "start game menu button pressed." in log["text"].lower() for log in start_logs
+            "start game menu button pressed." in log["text"].lower()
+            for log in start_logs
         ), "Start Game button not found"
         assert any(
             "initializing main scene..." in log["text"].lower() for log in start_logs

--- a/tests/difficulty_flow_test.py
+++ b/tests/difficulty_flow_test.py
@@ -7,13 +7,15 @@ Difficulty State Test (Playwright + UI Automation with DOM Overlays)
 
 Overview
 --------
-Robust E2E test: Sets difficulty=2.0 via UI (click #options-button, set #difficulty-slider), starts game, simulates fire, verifies persistence (cooldown via log).
-No coords - DOM overlays for IDs.
+Robust E2E test: Sets difficulty=2.0 via UI (click #options-button, set
+#difficulty-slider), starts game, simulates fire, verifies persistence (cooldown
+via log). No coords - DOM overlays for IDs.
 
 Test Flow
 ---------
 - Navigate, wait #options-button.
-- Click #options-button, wait for options loaded (via log), set #log-level-select to DEBUG, set #difficulty-slider to 2.0, click #back-button.
+- Click #options-button, wait for options loaded (via log), set #log-level-select
+  to DEBUG, set #difficulty-slider to 2.0, click #back-button.
 - Click #start-button, simulate fire (Space), parse cooldown log (0.15*2.0=0.3).
 - CDP V8 coverage saved.
 
@@ -50,7 +52,8 @@ def test_difficulty_flow(page: Page) -> None:
 
     Test that invisible HTML overlays allow passthrough clicks to Godot UI.
 
-    Verifies overlays are present, invisible, and do not block events (via log check after click).
+    Verifies overlays are present, invisible, and do not block events.
+
     :param page: The Playwright page object.
     :type page: Page
     :rtype: None
@@ -61,6 +64,7 @@ def test_difficulty_flow(page: Page) -> None:
     def on_console(msg: Any) -> None:
         """
         Console message handler.
+
         :param msg: The console message.
         :type msg: Any
         :rtype: None
@@ -74,16 +78,15 @@ def test_difficulty_flow(page: Page) -> None:
         start_idx: int,
         timeout_ms: int = DEFAULT_TIMEOUT,
     ) -> None:
-        """
-        Helper to poll until a matching console log arrives or timeout expires.
-        """
+        """Helper to poll until a matching console log arrives or timeout expires."""
         start_time = time.time()
         while (time.time() - start_time) * 1000 < timeout_ms:
             if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
                 return
             page.wait_for_timeout(50)  # Micro-poll for event loop progression
         pytest.fail(
-            f"Timed out waiting for expected console log matching predicate after {timeout_ms}ms"
+            "Timed out waiting for expected console log matching "
+            f"predicate after {timeout_ms}ms"
         )
 
     try:
@@ -118,13 +121,17 @@ def test_difficulty_flow(page: Page) -> None:
 
         # Check invisible (opacity 0)
         opacity: str = page.evaluate(
-            "window.getComputedStyle(document.getElementById('options-button')).opacity"
+            "window.getComputedStyle("
+            "document.getElementById('options-button')"
+            ").opacity"
         )
         assert opacity == "0", f"Expected opacity 0, got {opacity}"
 
         # Check pointer-events none
         pointer_events: str = page.evaluate(
-            "window.getComputedStyle(document.getElementById('options-button')).pointerEvents"
+            "window.getComputedStyle("
+            "document.getElementById('options-button')"
+            ").pointerEvents"
         )
         assert (
             pointer_events == "none"
@@ -155,7 +162,9 @@ def test_difficulty_flow(page: Page) -> None:
             "() => typeof window.changeLogLevel !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.wait_for_function(
-            "() => window.getComputedStyle(document.getElementById('log-level-select')).display === 'block'",
+            "() => window.getComputedStyle("
+            "document.getElementById('log-level-select')"
+            ").display === 'block'",
             timeout=TEST_TIMEOUT,
         )
 
@@ -179,7 +188,7 @@ def test_difficulty_flow(page: Page) -> None:
             ("encrypted" in log["text"].lower() and "settings" in log["text"].lower())
             or "falling back to plaintext" in log["text"].lower()
             for log in new_logs
-        ), "Failed to save the settings (neither encrypted save nor plaintext fallback detected)"
+        ), "Failed to save settings (neither encrypted save nor fallback detected)"
 
         # Go back to Options menu
         page.wait_for_selector(
@@ -282,8 +291,8 @@ def test_difficulty_flow(page: Page) -> None:
             "#difficulty-slider", state="hidden", timeout=TEST_TIMEOUT
         )
         assert page.evaluate(
-            "document.getElementById('difficulty-slider') === null || document.getElementById("
-            "'difficulty-slider').offsetParent === null"
+            "document.getElementById('difficulty-slider') === null || "
+            "document.getElementById('difficulty-slider').offsetParent === null"
         )
 
         # Check element present
@@ -300,8 +309,8 @@ def test_difficulty_flow(page: Page) -> None:
             "#options-back-button", state="hidden", timeout=TEST_TIMEOUT
         )
         assert page.evaluate(
-            "document.getElementById('options-back-button') === null || document.getElementById("
-            "'options-back-button').offsetParent === null"
+            "document.getElementById('options-back-button') === null || "
+            "document.getElementById('options-back-button').offsetParent === null"
         )
 
         # Start game
@@ -383,7 +392,9 @@ def test_difficulty_flow(page: Page) -> None:
             f.write(page.content())
 
         print(
-            f"Failure logs: artifacts/test_difficulty_failure_console_logs_{timestamp}.txt. Error: {e}"
+            "Failure logs: "
+            f"artifacts/test_difficulty_failure_console_logs_{timestamp}.txt. "
+            f"Error: {e}"
         )
         raise
     finally:

--- a/tests/difficulty_flow_test.py
+++ b/tests/difficulty_flow_test.py
@@ -200,9 +200,9 @@ def test_difficulty_flow(page: Page) -> None:
         ), "Audio button not found/displayed"
 
         # Allow either standard encrypted saves (native) OR plaintext fallbacks (WebGL)
-        assert _has_save_log(new_logs), (
-            "Failed to save settings (neither encrypted save nor fallback detected)"
-        )
+        assert _has_save_log(
+            new_logs
+        ), "Failed to save settings (neither encrypted save nor fallback detected)"
 
         # Go back to Options menu
         page.wait_for_selector(

--- a/tests/difficulty_flow_test.py
+++ b/tests/difficulty_flow_test.py
@@ -34,15 +34,13 @@ v8_coverage_difficulty_flow_test.json, artifacts/test_difficulty_failure_*.png/t
 import json
 import os
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
-from playwright.sync_api import Page
+import pytest
+from playwright.sync_api import Page, expect
 
 # Configuration for stability in different environments
-# Default to 5000ms, but allow CI to override via environment variable
-DEFAULT_TIMEOUT = int(
-    os.getenv("TEST_TIMEOUT", "30000")
-)  # Fallback to 30s instead of 5s
+DEFAULT_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "30000"))
 TEST_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "5000"))
 
 
@@ -70,8 +68,22 @@ def test_difficulty_flow(page: Page) -> None:
         logs.append({"type": msg.type, "text": msg.text})
 
     page.on("console", on_console)
+
+    def wait_for_console_log(
+        predicate: Callable[[str], bool], start_idx: int, timeout_ms: int = DEFAULT_TIMEOUT
+    ) -> None:
+        """
+        Helper to poll until a matching console log arrives or timeout expires.
+        """
+        start_time = time.time()
+        while (time.time() - start_time) * 1000 < timeout_ms:
+            if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
+                return
+            page.wait_for_timeout(50)  # Micro-poll for event loop progression
+        pytest.fail(f"Timed out waiting for expected console log matching predicate after {timeout_ms}ms")
+
     try:
-        # Start CDP session for V8 JS coverage (workaround for Python Playwright lacking native coverage API)
+        # Start CDP session for V8 JS coverage
         cdp_session = page.context.new_cdp_session(page)
         cdp_session.send("Profiler.enable")
         cdp_session.send(
@@ -83,14 +95,13 @@ def test_difficulty_flow(page: Page) -> None:
             wait_until="networkidle",
             timeout=DEFAULT_TIMEOUT,
         )
-        # 1. Wait for the engine to actually start the splash scene
-        page.wait_for_timeout(TEST_TIMEOUT)
-        # Wait for Godot engine init (ensures 'godot' object is defined)
-        page.wait_for_function("() => window.godotInitialized", timeout=DEFAULT_TIMEOUT)
+
+        # 1. Wait deterministically for Godot engine initialization
+        page.wait_for_function("() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT)
 
         # Verify canvas and title to ensure game is initialized
         canvas = page.locator("canvas")
-        page.wait_for_selector("canvas", state="visible", timeout=DEFAULT_TIMEOUT)
+        expect(canvas).to_be_visible(timeout=DEFAULT_TIMEOUT)
         box: Optional[Dict[str, float]] = canvas.bounding_box()
         assert box is not None, "Canvas not found on page"
         assert "SkyLockAssault" in page.title(), "Title not found"
@@ -113,17 +124,16 @@ def test_difficulty_flow(page: Page) -> None:
             pointer_events == "none"
         ), f"Expected pointer-events none, got {pointer_events}"
 
-        # Wait main menu (function check for ID)
+        # Wait main menu
         page.wait_for_function(
             "() => document.getElementById('options-button') !== null",
             timeout=TEST_TIMEOUT,
-        )  # Longer for stalls
+        )
 
         # Open options
         page.wait_for_selector("#options-button", state="visible", timeout=TEST_TIMEOUT)
-        # page.click("#options-button", force=True)
         page.wait_for_function(
-            "window.optionsPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.optionsPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.optionsPressed([])")
 
@@ -131,25 +141,25 @@ def test_difficulty_flow(page: Page) -> None:
         page.wait_for_selector(
             "#advanced-button", state="visible", timeout=TEST_TIMEOUT
         )
-        # page.click("#advanced-button", force=True)
         page.wait_for_function(
-            "window.advancedPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.advancedPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.advancedPressed([])")
         page.wait_for_function(
-            "window.changeLogLevel !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.changeLogLevel !== 'undefined'", timeout=TEST_TIMEOUT
         )
-        advanced_display: str = page.evaluate(
-            "window.getComputedStyle(document.getElementById('log-level-select')).display"
+        page.wait_for_function(
+            "() => window.getComputedStyle(document.getElementById('log-level-select')).display === 'block'",
+            timeout=TEST_TIMEOUT,
         )
-        assert (
-            advanced_display == "block"
-        ), "Advanced menu not loaded (selected log level not displayed)"
 
         # Set log level DEBUG
         pre_change_log_count: int = len(logs)
         page.evaluate("window.changeLogLevel([0])")
-        page.wait_for_timeout(1000)
+        wait_for_console_log(
+            lambda text: "log level changed to: debug" in text,
+            start_idx=pre_change_log_count,
+        )
         new_logs: List[Dict[str, str]] = logs[pre_change_log_count:]
         assert any(
             "log level changed to: debug" in log["text"].lower() for log in new_logs
@@ -157,12 +167,6 @@ def test_difficulty_flow(page: Page) -> None:
         assert page.evaluate(
             "document.getElementById('audio-button') !== null"
         ), "Audio button not found/displayed"
-        assert any(
-            "Log level changed to: DEBUG" in log["text"] for log in new_logs
-        ), "Failed to set log level to DEBUG"
-        assert any(
-            "log level changed to: debug" in log["text"].lower() for log in new_logs
-        ), "Failed to set log level to DEBUG"
 
         # Allow either standard encrypted saves (native) OR plaintext fallbacks (WebGL)
         assert any(
@@ -175,9 +179,8 @@ def test_difficulty_flow(page: Page) -> None:
         page.wait_for_selector(
             "#advanced-back-button", state="visible", timeout=TEST_TIMEOUT
         )
-        # page.click("#advanced-back-button", force=True)
         page.wait_for_function(
-            "window.advancedBackPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.advancedBackPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.advancedBackPressed([])")
 
@@ -185,9 +188,8 @@ def test_difficulty_flow(page: Page) -> None:
         page.wait_for_selector(
             "#gameplay-button", state="visible", timeout=TEST_TIMEOUT
         )
-        # page.click("#advanced-back-button", force=True)
         page.wait_for_function(
-            "window.gameplayPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.gameplayPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.gameplayPressed([])")
 
@@ -199,13 +201,16 @@ def test_difficulty_flow(page: Page) -> None:
             "#options-back-button", state="hidden", timeout=TEST_TIMEOUT
         )
 
-        # Set difficulty to 2.0 - directly call the exposed callback (bypasses event for reliability in automation)
+        # Set difficulty to 2.0
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "window.changeDifficulty !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.changeDifficulty !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.changeDifficulty([2.0])")
-        page.wait_for_timeout(TEST_TIMEOUT)
+        wait_for_console_log(
+            lambda text: "js difficulty callback called with valid value: 2.0" in text,
+            start_idx=pre_change_log_count,
+        )
         new_logs = logs[pre_change_log_count:]
 
         assert any(
@@ -213,45 +218,51 @@ def test_difficulty_flow(page: Page) -> None:
             for log in new_logs
         ), "Failed to extract/validate difficulty 2.0 from JS payload"
 
-        # FIX: Look for the new encrypted save log instead of "settings saved"
         assert any(
             "encrypted" in log["text"].lower() and "settings" in log["text"].lower()
             for log in new_logs
         ), "Failed to save the settings"
 
-        # Reset gameplay settings back to defaults via the gameplay reset action
+        # Reset gameplay settings back to defaults
         pre_reset_log_count: int = len(logs)
         page.wait_for_function(
-            "window.gameplayResetPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.gameplayResetPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.gameplayResetPressed([])")
-        page.wait_for_timeout(TEST_TIMEOUT)
+        wait_for_console_log(
+            lambda text: "setting 'difficulty' updated to: 1" in text,
+            start_idx=pre_reset_log_count,
+        )
         reset_logs: List[Dict[str, str]] = logs[pre_reset_log_count:]
 
-        # Verify that difficulty was reset to the expected default
         assert any(
             "setting 'difficulty' updated to: 1" in log["text"].lower()
             for log in reset_logs
         ), "Resource did not reset difficulty to 1.0 after reset button press"
 
         # Set difficulty to 2.0 again
+        pre_change_log_count = len(logs)
         page.evaluate("window.changeDifficulty([2.0])")
-        page.wait_for_timeout(TEST_TIMEOUT)
+        wait_for_console_log(
+            lambda text: "js difficulty callback called with valid value: 2.0" in text,
+            start_idx=pre_change_log_count,
+        )
 
         # Back to Main menu
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "window.gameplayBackPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.gameplayBackPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.gameplayBackPressed([])")
-        page.wait_for_timeout(TEST_TIMEOUT)
+        wait_for_console_log(
+            lambda text: "back button pressed." in text,
+            start_idx=pre_change_log_count,
+        )
         new_logs = logs[pre_change_log_count:]
         assert any(
             "back button pressed." in log["text"].lower() for log in new_logs
         ), "Back button not found"
 
-        # After gameplayBackPressed([]), the options overlay should be visible again
-        # and gameplay-specific elements should be hidden.
         # Options overlay visible
         page.wait_for_selector(
             "#options-back-button", state="visible", timeout=TEST_TIMEOUT
@@ -273,8 +284,7 @@ def test_difficulty_flow(page: Page) -> None:
         assert page.evaluate("document.getElementById('options-back-button') !== null")
         page.evaluate("window.optionsBackPressed([])")
 
-        # After optionsBackPressed([]), we should be back on the main menu:
-        # main-menu elements visible and options elements hidden.
+        # After optionsBackPressed([]), back on the main menu
         page.wait_for_selector("#start-button", state="visible", timeout=TEST_TIMEOUT)
         assert page.evaluate("document.getElementById('start-button') !== null")
         page.wait_for_selector(
@@ -287,63 +297,65 @@ def test_difficulty_flow(page: Page) -> None:
 
         # Start game
         page.wait_for_selector("#start-button", state="visible", timeout=TEST_TIMEOUT)
-        pre_change_log_count = len(logs)
-        pre_poll_log_count: int = len(logs)
+        pre_start_log_count = len(logs)
         page.click("#start-button", force=True)
-        page.wait_for_timeout(
-            5000
-        )  # Sometimes it takes longer time to pass the loading screen
-        new_logs = logs[pre_change_log_count:]
+
+        # Wait deterministically for start button click and loading start
+        wait_for_console_log(
+            lambda text: "start game menu button pressed." in text,
+            start_idx=pre_start_log_count,
+            timeout_ms=TEST_TIMEOUT,
+        )
+
+        wait_for_console_log(
+            lambda text: "loading started successfully." in text,
+            start_idx=pre_start_log_count,
+            timeout_ms=DEFAULT_TIMEOUT,
+        )
+
+        # Wait deterministically for main scene initialization
+        wait_for_console_log(
+            lambda text: "initializing main scene..." in text,
+            start_idx=pre_start_log_count,
+            timeout_ms=DEFAULT_TIMEOUT,
+        )
+
+        # Wait deterministically for scene load completion
+        wait_for_console_log(
+            lambda text: "scene loaded successfully." in text,
+            start_idx=pre_start_log_count,
+            timeout_ms=DEFAULT_TIMEOUT,
+        )
+
+        start_logs = logs[pre_start_log_count:]
         assert any(
-            "start game menu button pressed." in log["text"].lower() for log in new_logs
+            "start game menu button pressed." in log["text"].lower() for log in start_logs
         ), "Start Game button not found"
         assert any(
-            "initializing main scene..." in log["text"].lower() for log in new_logs
+            "initializing main scene..." in log["text"].lower() for log in start_logs
         ), "Game scene not found"
 
-        # Poll for loading start log to confirm transition to loading screen
-        start_time: float = time.time()
-        while time.time() - start_time < 30:
-            if any(
-                "loading started successfully." in log["text"].lower()
-                for log in logs[pre_poll_log_count:]
-            ):
-                break
-            time.sleep(0.5)
-        else:
-            raise TimeoutError("Loading screen did not start")
-
-        # Poll for scene loaded log from loading_screen.gd
-        start_time = time.time()
-        while time.time() - start_time < 30:
-            if any(
-                "scene loaded successfully." in log["text"].lower()
-                for log in logs[pre_poll_log_count:]
-            ):
-                break
-            time.sleep(0.5)
-        else:
-            raise TimeoutError("Main scene not loaded")
-
         # Refocus canvas to ensure input capture
-        page.wait_for_selector("canvas", state="visible", timeout=TEST_TIMEOUT)
+        expect(canvas).to_be_visible(timeout=TEST_TIMEOUT)
         page.click("canvas")
 
         # Simulate fire (press Space)
-        pre_change_log_count = len(logs)
+        pre_fire_log_count = len(logs)
         page.keyboard.press("Space")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        new_logs = logs[pre_change_log_count:]
-        # Verify scaled cooldown in logs (fire_rate 0.15 * 2.0 = 0.3)
+        wait_for_console_log(
+            lambda text: "firing with scaled cooldown: 0.3" in text,
+            start_idx=pre_fire_log_count,
+            timeout_ms=TEST_TIMEOUT,
+        )
+        fire_logs = logs[pre_fire_log_count:]
         assert any(
             "firing with scaled cooldown: 0.3" in log["text"].lower()
-            for log in new_logs
+            for log in fire_logs
         ), "Scaled cooldown not found in logs"
 
     except Exception as e:
         print(f"Test: 'test_difficulty_flow' failed: {str(e)}")
         os.makedirs("artifacts", exist_ok=True)
-        # Artifact on failure
         timestamp: int = int(time.time())
         page.screenshot(
             path=f"artifacts/test_difficulty_failure_screenshot_{timestamp}.png"
@@ -366,7 +378,6 @@ def test_difficulty_flow(page: Page) -> None:
         raise
     finally:
         if cdp_session:
-            # Stop V8 coverage and save to file (even on failure)
             coverage: Dict[str, Any] = cdp_session.send("Profiler.takePreciseCoverage")[
                 "result"
             ]

--- a/tests/difficulty_flow_test.py
+++ b/tests/difficulty_flow_test.py
@@ -46,12 +46,44 @@ DEFAULT_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "30000"))
 TEST_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "5000"))
 
 
+def wait_for_console_log(
+    logs: List[Dict[str, str]],
+    predicate: Callable[[str], bool],
+    start_idx: int,
+    page: Page,
+    timeout_ms: int = DEFAULT_TIMEOUT,
+) -> None:
+    """Helper to poll until a matching console log arrives or timeout expires."""
+    start_time = time.time()
+    while (time.time() - start_time) * 1000 < timeout_ms:
+        if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
+            return
+        page.wait_for_timeout(50)  # Micro-poll for event loop progression
+    pytest.fail(
+        "Timed out waiting for expected console log matching "
+        f"predicate after {timeout_ms}ms"
+    )
+
+
+def _has_log(logs: List[Dict[str, str]], keyword: str) -> bool:
+    """Check if any log entry contains the specified keyword."""
+    return any(keyword in log["text"].lower() for log in logs)
+
+
+def _has_save_log(logs: List[Dict[str, str]]) -> bool:
+    """Check if any log entry indicates settings were saved."""
+    return any(
+        ("encrypted" in log["text"].lower() and "settings" in log["text"].lower())
+        or "falling back to plaintext" in log["text"].lower()
+        for log in logs
+    )
+
+
 def test_difficulty_flow(page: Page) -> None:
     """
     Main test for difficulty flow using DOM overlays.
 
     Test that invisible HTML overlays allow passthrough clicks to Godot UI.
-
     Verifies overlays are present, invisible, and do not block events.
 
     :param page: The Playwright page object.
@@ -72,22 +104,6 @@ def test_difficulty_flow(page: Page) -> None:
         logs.append({"type": msg.type, "text": msg.text})
 
     page.on("console", on_console)
-
-    def wait_for_console_log(
-        predicate: Callable[[str], bool],
-        start_idx: int,
-        timeout_ms: int = DEFAULT_TIMEOUT,
-    ) -> None:
-        """Helper to poll until a matching console log arrives or timeout expires."""
-        start_time = time.time()
-        while (time.time() - start_time) * 1000 < timeout_ms:
-            if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
-                return
-            page.wait_for_timeout(50)  # Micro-poll for event loop progression
-        pytest.fail(
-            "Timed out waiting for expected console log matching "
-            f"predicate after {timeout_ms}ms"
-        )
 
     try:
         # Start CDP session for V8 JS coverage
@@ -172,23 +188,21 @@ def test_difficulty_flow(page: Page) -> None:
         pre_change_log_count: int = len(logs)
         page.evaluate("window.changeLogLevel([0])")
         wait_for_console_log(
+            logs,
             lambda text: "log level changed to: debug" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
         new_logs: List[Dict[str, str]] = logs[pre_change_log_count:]
-        assert any(
-            "log level changed to: debug" in log["text"].lower() for log in new_logs
-        )
+        assert _has_log(new_logs, "log level changed to: debug")
         assert page.evaluate(
             "document.getElementById('audio-button') !== null"
         ), "Audio button not found/displayed"
 
         # Allow either standard encrypted saves (native) OR plaintext fallbacks (WebGL)
-        assert any(
-            ("encrypted" in log["text"].lower() and "settings" in log["text"].lower())
-            or "falling back to plaintext" in log["text"].lower()
-            for log in new_logs
-        ), "Failed to save settings (neither encrypted save nor fallback detected)"
+        assert _has_save_log(new_logs), (
+            "Failed to save settings (neither encrypted save nor fallback detected)"
+        )
 
         # Go back to Options menu
         page.wait_for_selector(
@@ -224,20 +238,18 @@ def test_difficulty_flow(page: Page) -> None:
         )
         page.evaluate("window.changeDifficulty([2.0])")
         wait_for_console_log(
+            logs,
             lambda text: "js difficulty callback called with valid value: 2.0" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
         new_logs = logs[pre_change_log_count:]
 
-        assert any(
-            "js difficulty callback called with valid value: 2.0" in log["text"].lower()
-            for log in new_logs
+        assert _has_log(
+            new_logs, "js difficulty callback called with valid value: 2.0"
         ), "Failed to extract/validate difficulty 2.0 from JS payload"
 
-        assert any(
-            "encrypted" in log["text"].lower() and "settings" in log["text"].lower()
-            for log in new_logs
-        ), "Failed to save the settings"
+        assert _has_save_log(new_logs), "Failed to save the settings"
 
         # Reset gameplay settings back to defaults
         pre_reset_log_count: int = len(logs)
@@ -247,22 +259,25 @@ def test_difficulty_flow(page: Page) -> None:
         )
         page.evaluate("window.gameplayResetPressed([])")
         wait_for_console_log(
+            logs,
             lambda text: "setting 'difficulty' updated to: 1" in text,
-            start_idx=pre_reset_log_count,
+            pre_reset_log_count,
+            page,
         )
         reset_logs: List[Dict[str, str]] = logs[pre_reset_log_count:]
 
-        assert any(
-            "setting 'difficulty' updated to: 1" in log["text"].lower()
-            for log in reset_logs
+        assert _has_log(
+            reset_logs, "setting 'difficulty' updated to: 1"
         ), "Resource did not reset difficulty to 1.0 after reset button press"
 
         # Set difficulty to 2.0 again
         pre_change_log_count = len(logs)
         page.evaluate("window.changeDifficulty([2.0])")
         wait_for_console_log(
+            logs,
             lambda text: "js difficulty callback called with valid value: 2.0" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
 
         # Back to Main menu
@@ -273,13 +288,13 @@ def test_difficulty_flow(page: Page) -> None:
         )
         page.evaluate("window.gameplayBackPressed([])")
         wait_for_console_log(
+            logs,
             lambda text: "back button pressed." in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
         new_logs = logs[pre_change_log_count:]
-        assert any(
-            "back button pressed." in log["text"].lower() for log in new_logs
-        ), "Back button not found"
+        assert _has_log(new_logs, "back button pressed."), "Back button not found"
 
         # Options overlay visible
         page.wait_for_selector(
@@ -320,38 +335,45 @@ def test_difficulty_flow(page: Page) -> None:
 
         # Wait deterministically for start button click and loading start
         wait_for_console_log(
+            logs,
             lambda text: "start game menu button pressed." in text,
-            start_idx=pre_start_log_count,
+            pre_start_log_count,
+            page,
             timeout_ms=TEST_TIMEOUT,
         )
 
         wait_for_console_log(
+            logs,
             lambda text: "loading started successfully." in text,
-            start_idx=pre_start_log_count,
+            pre_start_log_count,
+            page,
             timeout_ms=DEFAULT_TIMEOUT,
         )
 
         # Wait deterministically for main scene initialization
         wait_for_console_log(
+            logs,
             lambda text: "initializing main scene..." in text,
-            start_idx=pre_start_log_count,
+            pre_start_log_count,
+            page,
             timeout_ms=DEFAULT_TIMEOUT,
         )
 
         # Wait deterministically for scene load completion
         wait_for_console_log(
+            logs,
             lambda text: "scene loaded successfully." in text,
-            start_idx=pre_start_log_count,
+            pre_start_log_count,
+            page,
             timeout_ms=DEFAULT_TIMEOUT,
         )
 
         start_logs = logs[pre_start_log_count:]
-        assert any(
-            "start game menu button pressed." in log["text"].lower()
-            for log in start_logs
+        assert _has_log(
+            start_logs, "start game menu button pressed."
         ), "Start Game button not found"
-        assert any(
-            "initializing main scene..." in log["text"].lower() for log in start_logs
+        assert _has_log(
+            start_logs, "initializing main scene..."
         ), "Game scene not found"
 
         # Refocus canvas to ensure input capture
@@ -362,14 +384,15 @@ def test_difficulty_flow(page: Page) -> None:
         pre_fire_log_count = len(logs)
         page.keyboard.press("Space")
         wait_for_console_log(
+            logs,
             lambda text: "firing with scaled cooldown: 0.3" in text,
-            start_idx=pre_fire_log_count,
+            pre_fire_log_count,
+            page,
             timeout_ms=TEST_TIMEOUT,
         )
         fire_logs = logs[pre_fire_log_count:]
-        assert any(
-            "firing with scaled cooldown: 0.3" in log["text"].lower()
-            for log in fire_logs
+        assert _has_log(
+            fire_logs, "firing with scaled cooldown: 0.3"
         ), "Scaled cooldown not found in logs"
 
     except Exception as e:

--- a/tests/difficulty_flow_test.py
+++ b/tests/difficulty_flow_test.py
@@ -42,27 +42,7 @@ import pytest
 from playwright.sync_api import Page, expect
 
 # Configuration for stability in different environments
-DEFAULT_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "30000"))
-TEST_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "5000"))
-
-
-def wait_for_console_log(
-    logs: List[Dict[str, str]],
-    predicate: Callable[[str], bool],
-    start_idx: int,
-    page: Page,
-    timeout_ms: int = DEFAULT_TIMEOUT,
-) -> None:
-    """Helper to poll until a matching console log arrives or timeout expires."""
-    start_time = time.time()
-    while (time.time() - start_time) * 1000 < timeout_ms:
-        if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
-            return
-        page.wait_for_timeout(50)  # Micro-poll for event loop progression
-    pytest.fail(
-        "Timed out waiting for expected console log matching "
-        f"predicate after {timeout_ms}ms"
-    )
+from tests.test_utils import DEFAULT_TIMEOUT, TEST_TIMEOUT, wait_for_console_log
 
 
 def _has_log(logs: List[Dict[str, str]], keyword: str) -> bool:

--- a/tests/difficulty_flow_test.py
+++ b/tests/difficulty_flow_test.py
@@ -38,7 +38,6 @@ import os
 import time
 from typing import Any, Callable, Dict, List, Optional
 
-import pytest
 from playwright.sync_api import Page, expect
 
 # Configuration for stability in different environments

--- a/tests/load_main_menu_test.py
+++ b/tests/load_main_menu_test.py
@@ -82,7 +82,9 @@ def test_load_main_menu(page: Page) -> None:
         )
 
         # Wait deterministically for Godot engine initialization
-        page.wait_for_function("() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT)
+        page.wait_for_function(
+            "() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT
+        )
 
         # Verify canvas and title to ensure game is initialized
         canvas = page.locator("canvas")

--- a/tests/load_main_menu_test.py
+++ b/tests/load_main_menu_test.py
@@ -37,10 +37,9 @@ import json
 import os
 import time
 
-from playwright.sync_api import Page
+from playwright.sync_api import Page, expect
 
 # Configuration for stability in different environments
-# Default to 5000ms, but allow CI to override via environment variable
 DEFAULT_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "30000"))
 TEST_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "5000"))
 
@@ -69,7 +68,7 @@ def test_load_main_menu(page: Page) -> None:
 
     page.on("console", on_console)
     try:
-        # Start CDP session for V8 JS coverage (workaround for Python Playwright lacking native coverage API)
+        # Start CDP session for V8 JS coverage
         cdp_session = page.context.new_cdp_session(page)
         cdp_session.send("Profiler.enable")
         cdp_session.send(
@@ -81,32 +80,25 @@ def test_load_main_menu(page: Page) -> None:
             wait_until="networkidle",
             timeout=DEFAULT_TIMEOUT,
         )
-        # 1. Wait for the engine to actually start the splash scene
-        page.wait_for_timeout(TEST_TIMEOUT)
-        # Wait for Godot engine init (ensures 'godot' object is defined)
-        page.wait_for_function("() => window.godotInitialized", timeout=DEFAULT_TIMEOUT)
+
+        # Wait deterministically for Godot engine initialization
+        page.wait_for_function("() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT)
 
         # Verify canvas and title to ensure game is initialized
         canvas = page.locator("canvas")
-        page.wait_for_selector("canvas", state="visible", timeout=DEFAULT_TIMEOUT)
+        expect(canvas).to_be_visible(timeout=DEFAULT_TIMEOUT)
         box: dict[str, float] | None = canvas.bounding_box()
         assert box is not None, "Canvas not found on page"
         assert "SkyLockAssault" in page.title(), "Title not found"
 
-        # Since the DOM overlays are now central to the web flow,
-        # consider also asserting that the main-menu overlay elements are present
-        # and visible (similar to navigation_to_audio_test):
-        page.wait_for_selector("#start-button", state="visible", timeout=TEST_TIMEOUT)
-        assert page.evaluate("document.getElementById('start-button') !== null")
-        page.wait_for_selector("#options-button", state="visible", timeout=TEST_TIMEOUT)
-        assert page.evaluate("document.getElementById('options-button') !== null")
-        page.wait_for_selector("#quit-button", state="visible", timeout=TEST_TIMEOUT)
-        assert page.evaluate("document.getElementById('quit-button') !== null")
+        # Assert main-menu DOM overlay elements are present and visible
+        expect(page.locator("#start-button")).to_be_visible(timeout=TEST_TIMEOUT)
+        expect(page.locator("#options-button")).to_be_visible(timeout=TEST_TIMEOUT)
+        expect(page.locator("#quit-button")).to_be_visible(timeout=TEST_TIMEOUT)
 
     except Exception as e:
         print(f"Test: 'test_load_main_menu' failed: {str(e)}")
         os.makedirs("artifacts", exist_ok=True)
-        # Artifact on failure
         timestamp = int(time.time())
         page.screenshot(
             path=f"artifacts/test_load_main_menu_failure_screenshot_{timestamp}.png"

--- a/tests/load_main_menu_test.py
+++ b/tests/load_main_menu_test.py
@@ -40,8 +40,7 @@ import time
 from playwright.sync_api import Page, expect
 
 # Configuration for stability in different environments
-DEFAULT_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "30000"))
-TEST_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "5000"))
+from tests.test_utils import DEFAULT_TIMEOUT, TEST_TIMEOUT
 
 
 def test_load_main_menu(page: Page) -> None:

--- a/tests/navigation_to_audio_test.py
+++ b/tests/navigation_to_audio_test.py
@@ -75,7 +75,9 @@ def test_navigation_to_audio(page: Page) -> None:
             if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
                 return
             page.wait_for_timeout(50)  # Micro-poll for event loop progression
-        pytest.fail(f"Timed out waiting for expected console log matching predicate after {timeout_ms}ms")
+        pytest.fail(
+            f"Timed out waiting for expected console log matching predicate after {timeout_ms}ms"
+        )
 
     try:
         # Start CDP session for V8 JS coverage (workaround for Python Playwright lacking native coverage API)
@@ -92,7 +94,9 @@ def test_navigation_to_audio(page: Page) -> None:
         )
 
         # 1. Wait deterministically for Godot engine initialization
-        page.wait_for_function("() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT)
+        page.wait_for_function(
+            "() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT
+        )
 
         # Verify canvas
         canvas = page.locator("canvas")
@@ -155,7 +159,8 @@ def test_navigation_to_audio(page: Page) -> None:
             "#advanced-back-button", state="visible", timeout=TEST_TIMEOUT
         )
         page.wait_for_function(
-            "() => typeof window.advancedBackPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.advancedBackPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.advancedBackPressed([])")
 

--- a/tests/navigation_to_audio_test.py
+++ b/tests/navigation_to_audio_test.py
@@ -28,8 +28,10 @@ v8_coverage_navigation_to_audio_test.json, artifacts/test_navigation_failure_*.p
 import json
 import os
 import time
+from typing import Any, Callable
 
-from playwright.sync_api import Page
+import pytest
+from playwright.sync_api import Page, expect
 
 # Configuration for stability in different environments
 # Default to 5000ms, but allow CI to override via environment variable
@@ -50,7 +52,7 @@ def test_navigation_to_audio(page: Page) -> None:
     logs: list[dict[str, str]] = []
     cdp_session = None
 
-    def on_console(msg) -> None:
+    def on_console(msg: Any) -> None:
         """
         Console message handler to capture logs.
 
@@ -61,6 +63,20 @@ def test_navigation_to_audio(page: Page) -> None:
         logs.append({"type": msg.type, "text": msg.text})
 
     page.on("console", on_console)
+
+    def wait_for_console_log(
+        predicate: Callable[[str], bool], start_idx: int, timeout_ms: int = TEST_TIMEOUT
+    ) -> None:
+        """
+        Helper to poll until a matching console log arrives or timeout expires.
+        """
+        start_time = time.time()
+        while (time.time() - start_time) * 1000 < timeout_ms:
+            if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
+                return
+            page.wait_for_timeout(50)  # Micro-poll for event loop progression
+        pytest.fail(f"Timed out waiting for expected console log matching predicate after {timeout_ms}ms")
+
     try:
         # Start CDP session for V8 JS coverage (workaround for Python Playwright lacking native coverage API)
         cdp_session = page.context.new_cdp_session(page)
@@ -74,24 +90,22 @@ def test_navigation_to_audio(page: Page) -> None:
             wait_until="networkidle",
             timeout=DEFAULT_TIMEOUT,
         )
-        # 1. Wait for the engine to actually start the splash scene
-        page.wait_for_timeout(TEST_TIMEOUT)
-        page.wait_for_function("() => window.godotInitialized", timeout=DEFAULT_TIMEOUT)
+
+        # 1. Wait deterministically for Godot engine initialization
+        page.wait_for_function("() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT)
 
         # Verify canvas
         canvas = page.locator("canvas")
-        page.wait_for_selector("canvas", state="visible", timeout=DEFAULT_TIMEOUT)
+        expect(canvas).to_be_visible(timeout=DEFAULT_TIMEOUT)
         box: dict[str, float] | None = canvas.bounding_box()
         assert box is not None, "Canvas not found"
         assert "SkyLockAssault" in page.title(), "Title not found"
 
         # NAV-01: Verify main menu overlays exist and are configured
-        page.wait_for_selector("#start-button", state="visible", timeout=TEST_TIMEOUT)
-        assert page.evaluate("document.getElementById('start-button') !== null")
-        page.wait_for_selector("#options-button", state="visible", timeout=TEST_TIMEOUT)
-        assert page.evaluate("document.getElementById('options-button') !== null")
-        page.wait_for_selector("#quit-button", state="visible", timeout=TEST_TIMEOUT)
-        assert page.evaluate("document.getElementById('quit-button') !== null")
+        expect(page.locator("#start-button")).to_be_visible(timeout=TEST_TIMEOUT)
+        expect(page.locator("#options-button")).to_be_visible(timeout=TEST_TIMEOUT)
+        expect(page.locator("#quit-button")).to_be_visible(timeout=TEST_TIMEOUT)
+
         opacity: str = page.evaluate(
             "window.getComputedStyle(document.getElementById('options-button')).opacity"
         )
@@ -104,11 +118,8 @@ def test_navigation_to_audio(page: Page) -> None:
         ), f"Expected pointer-events none, got {pointer_events}"
 
         # NAV-02: Navigate to options menu
-        # Open options
-        page.wait_for_selector("#options-button", state="visible", timeout=TEST_TIMEOUT)
-        # page.click("#options-button", force=True)
         page.wait_for_function(
-            "window.optionsPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.optionsPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.optionsPressed([])")
 
@@ -116,29 +127,24 @@ def test_navigation_to_audio(page: Page) -> None:
         page.wait_for_selector(
             "#advanced-button", state="visible", timeout=TEST_TIMEOUT
         )
-        # page.click("#advanced-button", force=True)
         page.wait_for_function(
-            "window.advancedPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.advancedPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.advancedPressed([])")
         page.wait_for_function(
-            "window.changeLogLevel !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.changeLogLevel !== 'undefined'", timeout=TEST_TIMEOUT
         )
-        advanced_display: str = page.evaluate(
-            "window.getComputedStyle(document.getElementById('log-level-select')).display"
+        page.wait_for_function(
+            "() => window.getComputedStyle(document.getElementById('log-level-select')).display === 'block'",
+            timeout=TEST_TIMEOUT,
         )
-        assert (
-            advanced_display == "block"
-        ), "Advanced menu not loaded (selected log level not displayed)"
 
         # NAV-03: Set log level to DEBUG
-        # Set log level DEBUG
         pre_change_log_count = len(logs)
         page.evaluate("window.changeLogLevel([0])")
-        page.wait_for_timeout(1000)
-        new_logs = logs[pre_change_log_count:]
-        assert any(
-            "log level changed to: debug" in log["text"].lower() for log in new_logs
+        wait_for_console_log(
+            lambda text: "log level changed to: debug" in text,
+            start_idx=pre_change_log_count,
         )
         assert page.evaluate(
             "document.getElementById('audio-button') !== null"
@@ -148,9 +154,8 @@ def test_navigation_to_audio(page: Page) -> None:
         page.wait_for_selector(
             "#advanced-back-button", state="visible", timeout=TEST_TIMEOUT
         )
-        # page.click("#advanced-back-button", force=True)
         page.wait_for_function(
-            "window.advancedBackPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.advancedBackPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.advancedBackPressed([])")
 
@@ -161,12 +166,21 @@ def test_navigation_to_audio(page: Page) -> None:
         ), "Audio button not found/displayed"
 
         # Open audio
-        # page.click("#audio-button", force=True, timeout=1500)
+        pre_audio_log_count = len(logs)
         page.wait_for_function(
-            "window.audioPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.audioPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.audioPressed([0])")
-        page.wait_for_timeout(TEST_TIMEOUT)  # Wait for audio scene load and JS eval
+
+        # Wait deterministically for master slider display and console log
+        page.wait_for_function(
+            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'block'",
+            timeout=TEST_TIMEOUT,
+        )
+        wait_for_console_log(
+            lambda text: "audio button pressed." in text,
+            start_idx=pre_audio_log_count,
+        )
 
         # Assert gameplay/options UI is hidden while audio menu is open
         gameplay_button_display_in_audio: str = page.evaluate(
@@ -176,44 +190,24 @@ def test_navigation_to_audio(page: Page) -> None:
             gameplay_button_display_in_audio == "none"
         ), "Gameplay button should be hidden while audio menu is open"
 
-        audio_display: str = page.evaluate(
-            "window.getComputedStyle(document.getElementById('master-slider')).display"
-        )
-        assert (
-            audio_display == "block"
-        ), "Audio menu not loaded (master-slider not displayed)"
-        assert any(
-            "audio button pressed." in log["text"].lower() for log in logs
-        ), "Audio navigation log not found"
-
         # Navigate back from audio menu
         page.wait_for_selector(
             "#audio-back-button", state="visible", timeout=TEST_TIMEOUT
         )
-        # page.click("#audio-back-button", force=True, timeout=1500)
         page.wait_for_function(
-            "window.audioBackPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.audioBackPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.audioBackPressed([])")
-        page.wait_for_timeout(
-            TEST_TIMEOUT
-        )  # Wait for audio overlay to hide and main/options overlays to re-show
 
-        # Assert audio overlay is hidden again
-        audio_display_after_back: str = page.evaluate(
-            "window.getComputedStyle(document.getElementById('master-slider')).display"
+        # Assert audio overlay is hidden again and options overlay is restored deterministically
+        page.wait_for_function(
+            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'none'",
+            timeout=TEST_TIMEOUT,
         )
-        assert (
-            audio_display_after_back == "none"
-        ), "Audio menu still visible after navigating back from audio menu"
-
-        # Assert main/options overlays are restored
-        options_overlay_display: str = page.evaluate(
-            "window.getComputedStyle(document.getElementById('gameplay-button')).display"
+        page.wait_for_function(
+            "() => window.getComputedStyle(document.getElementById('gameplay-button')).display === 'block'",
+            timeout=TEST_TIMEOUT,
         )
-        assert (
-            options_overlay_display == "block"
-        ), "Options overlay not restored after exiting audio menu"
 
     except Exception as e:
         print(f"Test suite failed: {str(e)}")

--- a/tests/navigation_to_audio_test.py
+++ b/tests/navigation_to_audio_test.py
@@ -177,9 +177,7 @@ def test_navigation_to_audio(page: Page) -> None:
         page.evaluate("window.advancedBackPressed([])")
 
         # NAV-04: Navigate to audio sub-menu
-        page.wait_for_selector(
-            "#audio-button", state="visible", timeout=TEST_TIMEOUT
-        )
+        page.wait_for_selector("#audio-button", state="visible", timeout=TEST_TIMEOUT)
         assert page.evaluate(
             "document.getElementById('audio-button') !== null"
         ), "Audio button not found/displayed"

--- a/tests/navigation_to_audio_test.py
+++ b/tests/navigation_to_audio_test.py
@@ -7,9 +7,11 @@ Navigation to Audio Settings Test Suite (Playwright + UI Automation with DOM Ove
 
 Overview
 --------
-E2E tests for NAV-01 to NAV-04: Validate main menu overlays, navigate to options, set log level to DEBUG, navigate to audio sub-menu, verify audio overlays.
+E2E tests for NAV-01 to NAV-04: Validate main menu overlays, navigate to options,
+set log level to DEBUG, navigate to audio sub-menu, verify audio overlays.
 
-Uses DOM overlays for main/options, coordinates for audio button (no overlay). Verifies display styles and console logs (DEBUG level).
+Uses DOM overlays for main/options, coordinates for audio button (no overlay).
+Verifies display styles and console logs (DEBUG level).
 
 Prerequisites
 -------------
@@ -34,16 +36,16 @@ import pytest
 from playwright.sync_api import Page, expect
 
 # Configuration for stability in different environments
-# Default to 5000ms, but allow CI to override via environment variable
 DEFAULT_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "30000"))
 TEST_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "5000"))
 
 
 def test_navigation_to_audio(page: Page) -> None:
     """
-    Main test suite for navigation to audio settings using DOM overlays and coordinates.
+    Main test suite for navigation to audio settings using DOM overlays.
 
-    Implements NAV-01 to NAV-04: Verify main menu overlays, open options, set DEBUG log level, open audio, verify overlays/logs.
+    Implements NAV-01 to NAV-04: Verify main menu overlays, open options, set DEBUG
+    log level, open audio, verify overlays/logs.
 
     :param page: The Playwright page object.
     :type page: Page
@@ -65,22 +67,23 @@ def test_navigation_to_audio(page: Page) -> None:
     page.on("console", on_console)
 
     def wait_for_console_log(
-        predicate: Callable[[str], bool], start_idx: int, timeout_ms: int = TEST_TIMEOUT
+        predicate: Callable[[str], bool],
+        start_idx: int,
+        timeout_ms: int = TEST_TIMEOUT,
     ) -> None:
-        """
-        Helper to poll until a matching console log arrives or timeout expires.
-        """
+        """Helper to poll until a matching console log arrives or timeout expires."""
         start_time = time.time()
         while (time.time() - start_time) * 1000 < timeout_ms:
             if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
                 return
             page.wait_for_timeout(50)  # Micro-poll for event loop progression
         pytest.fail(
-            f"Timed out waiting for expected console log matching predicate after {timeout_ms}ms"
+            "Timed out waiting for expected console log matching "
+            f"predicate after {timeout_ms}ms"
         )
 
     try:
-        # Start CDP session for V8 JS coverage (workaround for Python Playwright lacking native coverage API)
+        # Start CDP session for V8 JS coverage
         cdp_session = page.context.new_cdp_session(page)
         cdp_session.send("Profiler.enable")
         cdp_session.send(
@@ -111,11 +114,15 @@ def test_navigation_to_audio(page: Page) -> None:
         expect(page.locator("#quit-button")).to_be_visible(timeout=TEST_TIMEOUT)
 
         opacity: str = page.evaluate(
-            "window.getComputedStyle(document.getElementById('options-button')).opacity"
+            "window.getComputedStyle("
+            "document.getElementById('options-button')"
+            ").opacity"
         )
         assert opacity == "0", f"Expected opacity 0, got {opacity}"
         pointer_events: str = page.evaluate(
-            "window.getComputedStyle(document.getElementById('options-button')).pointerEvents"
+            "window.getComputedStyle("
+            "document.getElementById('options-button')"
+            ").pointerEvents"
         )
         assert (
             pointer_events == "none"
@@ -123,7 +130,8 @@ def test_navigation_to_audio(page: Page) -> None:
 
         # NAV-02: Navigate to options menu
         page.wait_for_function(
-            "() => typeof window.optionsPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.optionsPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.optionsPressed([])")
 
@@ -132,14 +140,18 @@ def test_navigation_to_audio(page: Page) -> None:
             "#advanced-button", state="visible", timeout=TEST_TIMEOUT
         )
         page.wait_for_function(
-            "() => typeof window.advancedPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.advancedPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.advancedPressed([])")
         page.wait_for_function(
-            "() => typeof window.changeLogLevel !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.changeLogLevel !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.wait_for_function(
-            "() => window.getComputedStyle(document.getElementById('log-level-select')).display === 'block'",
+            "() => window.getComputedStyle("
+            "document.getElementById('log-level-select')"
+            ").display === 'block'",
             timeout=TEST_TIMEOUT,
         )
 
@@ -165,7 +177,9 @@ def test_navigation_to_audio(page: Page) -> None:
         page.evaluate("window.advancedBackPressed([])")
 
         # NAV-04: Navigate to audio sub-menu
-        page.wait_for_selector("#audio-button", state="visible", timeout=TEST_TIMEOUT)
+        page.wait_for_selector(
+            "#audio-button", state="visible", timeout=TEST_TIMEOUT
+        )
         assert page.evaluate(
             "document.getElementById('audio-button') !== null"
         ), "Audio button not found/displayed"
@@ -173,13 +187,16 @@ def test_navigation_to_audio(page: Page) -> None:
         # Open audio
         pre_audio_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.audioPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.audioPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.audioPressed([0])")
 
         # Wait deterministically for master slider display and console log
         page.wait_for_function(
-            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'block'",
+            "() => window.getComputedStyle("
+            "document.getElementById('master-slider')"
+            ").display === 'block'",
             timeout=TEST_TIMEOUT,
         )
         wait_for_console_log(
@@ -189,7 +206,9 @@ def test_navigation_to_audio(page: Page) -> None:
 
         # Assert gameplay/options UI is hidden while audio menu is open
         gameplay_button_display_in_audio: str = page.evaluate(
-            "window.getComputedStyle(document.getElementById('gameplay-button')).display"
+            "window.getComputedStyle("
+            "document.getElementById('gameplay-button')"
+            ").display"
         )
         assert (
             gameplay_button_display_in_audio == "none"
@@ -200,17 +219,22 @@ def test_navigation_to_audio(page: Page) -> None:
             "#audio-back-button", state="visible", timeout=TEST_TIMEOUT
         )
         page.wait_for_function(
-            "() => typeof window.audioBackPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.audioBackPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.audioBackPressed([])")
 
-        # Assert audio overlay is hidden again and options overlay is restored deterministically
+        # Assert audio overlay is hidden and options overlay is restored
         page.wait_for_function(
-            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'none'",
+            "() => window.getComputedStyle("
+            "document.getElementById('master-slider')"
+            ").display === 'none'",
             timeout=TEST_TIMEOUT,
         )
         page.wait_for_function(
-            "() => window.getComputedStyle(document.getElementById('gameplay-button')).display === 'block'",
+            "() => window.getComputedStyle("
+            "document.getElementById('gameplay-button')"
+            ").display === 'block'",
             timeout=TEST_TIMEOUT,
         )
 
@@ -229,7 +253,6 @@ def test_navigation_to_audio(page: Page) -> None:
         raise
     finally:
         if cdp_session:
-            # Stop V8 coverage and save to file (even on failure)
             coverage = cdp_session.send("Profiler.takePreciseCoverage")["result"]
             cdp_session.send("Profiler.stopPreciseCoverage")
             cdp_session.send("Profiler.disable")

--- a/tests/navigation_to_audio_test.py
+++ b/tests/navigation_to_audio_test.py
@@ -30,12 +30,11 @@ v8_coverage_navigation_to_audio_test.json, artifacts/test_navigation_failure_*.p
 import json
 import os
 import time
-from typing import Any, Callable
+from typing import Any
 
 import pytest
 from playwright.sync_api import Page, expect
 
-# Configuration for stability in different environments
 from tests.test_utils import DEFAULT_TIMEOUT, TEST_TIMEOUT, wait_for_console_log
 
 
@@ -142,8 +141,10 @@ def test_navigation_to_audio(page: Page) -> None:
         pre_change_log_count = len(logs)
         page.evaluate("window.changeLogLevel([0])")
         wait_for_console_log(
+            logs,
             lambda text: "log level changed to: debug" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
         assert page.evaluate(
             "document.getElementById('audio-button') !== null"
@@ -181,8 +182,10 @@ def test_navigation_to_audio(page: Page) -> None:
             timeout=TEST_TIMEOUT,
         )
         wait_for_console_log(
+            logs,
             lambda text: "audio button pressed." in text,
-            start_idx=pre_audio_log_count,
+            pre_audio_log_count,
+            page,
         )
 
         # Assert gameplay/options UI is hidden while audio menu is open

--- a/tests/navigation_to_audio_test.py
+++ b/tests/navigation_to_audio_test.py
@@ -32,7 +32,6 @@ import os
 import time
 from typing import Any
 
-import pytest
 from playwright.sync_api import Page, expect
 
 from tests.test_utils import DEFAULT_TIMEOUT, TEST_TIMEOUT, wait_for_console_log

--- a/tests/navigation_to_audio_test.py
+++ b/tests/navigation_to_audio_test.py
@@ -36,8 +36,7 @@ import pytest
 from playwright.sync_api import Page, expect
 
 # Configuration for stability in different environments
-DEFAULT_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "30000"))
-TEST_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "5000"))
+from tests.test_utils import DEFAULT_TIMEOUT, TEST_TIMEOUT, wait_for_console_log
 
 
 def test_navigation_to_audio(page: Page) -> None:
@@ -65,22 +64,6 @@ def test_navigation_to_audio(page: Page) -> None:
         logs.append({"type": msg.type, "text": msg.text})
 
     page.on("console", on_console)
-
-    def wait_for_console_log(
-        predicate: Callable[[str], bool],
-        start_idx: int,
-        timeout_ms: int = TEST_TIMEOUT,
-    ) -> None:
-        """Helper to poll until a matching console log arrives or timeout expires."""
-        start_time = time.time()
-        while (time.time() - start_time) * 1000 < timeout_ms:
-            if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
-                return
-            page.wait_for_timeout(50)  # Micro-poll for event loop progression
-        pytest.fail(
-            "Timed out waiting for expected console log matching "
-            f"predicate after {timeout_ms}ms"
-        )
 
     try:
         # Start CDP session for V8 JS coverage

--- a/tests/no_error_logs_test.py
+++ b/tests/no_error_logs_test.py
@@ -64,7 +64,9 @@ def test_no_error_logs_after_load(page: Page) -> None:
         )
 
         # Wait deterministically for Godot engine initialization
-        page.wait_for_function("() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT)
+        page.wait_for_function(
+            "() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT
+        )
 
         # Ensure canvas is rendered and visible
         canvas = page.locator("canvas")

--- a/tests/no_error_logs_test.py
+++ b/tests/no_error_logs_test.py
@@ -22,14 +22,10 @@ import json
 import os
 import time
 
-from playwright.sync_api import Page
+from playwright.sync_api import Page, expect
 
 # Configuration for stability in different environments
-# Default to 5000ms, but allow CI to override via environment variable
-DEFAULT_TIMEOUT = int(
-    os.getenv("TEST_TIMEOUT", "30000")
-)  # Fallback to 30s instead of 5s
-BUFFER_TIMEOUT = 1000
+DEFAULT_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "30000"))
 TEST_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "5000"))
 
 
@@ -61,21 +57,18 @@ def test_no_error_logs_after_load(page: Page) -> None:
             "Profiler.startPreciseCoverage", {"callCount": True, "detailed": True}
         )
 
-        # Navigate and wait for the game to initialize
-        # Using the configurable DEFAULT_TIMEOUT for improved stability
         page.goto(
             "http://localhost:8080/index.html",
             wait_until="networkidle",
             timeout=DEFAULT_TIMEOUT,
         )
-        # 1. Wait for the engine to actually start the splash scene
-        page.wait_for_timeout(DEFAULT_TIMEOUT)
 
-        # Wait for the custom Godot initialization flag
-        page.wait_for_function("() => window.godotInitialized", timeout=DEFAULT_TIMEOUT)
+        # Wait deterministically for Godot engine initialization
+        page.wait_for_function("() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT)
 
-        # Allow a short buffer for any delayed post-load errors
-        page.wait_for_timeout(BUFFER_TIMEOUT)
+        # Ensure canvas is rendered and visible
+        canvas = page.locator("canvas")
+        expect(canvas).to_be_visible(timeout=DEFAULT_TIMEOUT)
 
         # Filter for error logs
         error_logs = [log for log in logs if log["type"] == "error"]

--- a/tests/no_error_logs_test.py
+++ b/tests/no_error_logs_test.py
@@ -25,8 +25,7 @@ import time
 from playwright.sync_api import Page, expect
 
 # Configuration for stability in different environments
-DEFAULT_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "30000"))
-TEST_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "5000"))
+from tests.test_utils import DEFAULT_TIMEOUT, TEST_TIMEOUT
 
 
 def test_no_error_logs_after_load(page: Page) -> None:

--- a/tests/no_error_logs_test.py
+++ b/tests/no_error_logs_test.py
@@ -72,6 +72,9 @@ def test_no_error_logs_after_load(page: Page) -> None:
         canvas = page.locator("canvas")
         expect(canvas).to_be_visible(timeout=DEFAULT_TIMEOUT)
 
+        # Deterministically wait for main menu UI overlays to be fully mounted/ready
+        page.wait_for_selector("#start-button", state="visible", timeout=TEST_TIMEOUT)
+
         # Filter for error logs
         error_logs = [log for log in logs if log["type"] == "error"]
 

--- a/tests/reset_audio_flow_test.py
+++ b/tests/reset_audio_flow_test.py
@@ -64,7 +64,7 @@ def test_reset_flow(page: Page) -> None:
     page.on("console", on_console)
 
     def wait_for_console_log(
-            predicate: Callable[[str], bool], start_idx: int, timeout_ms: int = TEST_TIMEOUT
+        predicate: Callable[[str], bool], start_idx: int, timeout_ms: int = TEST_TIMEOUT
     ) -> None:
         """
         Helper to poll until a matching console log arrives or timeout expires.
@@ -74,7 +74,9 @@ def test_reset_flow(page: Page) -> None:
             if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
                 return
             page.wait_for_timeout(50)  # Micro-poll for event loop progression
-        pytest.fail(f"Timed out waiting for expected console log matching predicate after {timeout_ms}ms")
+        pytest.fail(
+            f"Timed out waiting for expected console log matching predicate after {timeout_ms}ms"
+        )
 
     try:
         # Start CDP session for V8 JS coverage
@@ -91,7 +93,9 @@ def test_reset_flow(page: Page) -> None:
         )
 
         # 1. Wait deterministically for Godot engine initialization
-        page.wait_for_function("() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT)
+        page.wait_for_function(
+            "() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT
+        )
 
         # Verify canvas
         canvas = page.locator("canvas")
@@ -139,7 +143,8 @@ def test_reset_flow(page: Page) -> None:
             "#advanced-back-button", state="visible", timeout=TEST_TIMEOUT
         )
         page.wait_for_function(
-            "() => typeof window.advancedBackPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.advancedBackPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.advancedBackPressed([])")
 
@@ -166,11 +171,13 @@ def test_reset_flow(page: Page) -> None:
 
         # RESET-01: Reset all buses to defaults
         page.wait_for_function(
-            "() => typeof window.changeMasterVolume !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.changeMasterVolume !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.changeMasterVolume([0.5])")
         page.wait_for_function(
-            "() => typeof window.changeMusicVolume !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.changeMusicVolume !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.changeMusicVolume([0.3])")
         page.wait_for_function(
@@ -188,7 +195,8 @@ def test_reset_flow(page: Page) -> None:
 
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.audioResetPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.audioResetPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.audioResetPressed([])")
 
@@ -198,22 +206,22 @@ def test_reset_flow(page: Page) -> None:
         )
 
         assert (
-                float(page.evaluate("document.getElementById('master-slider').value"))
-                == 1.0
+            float(page.evaluate("document.getElementById('master-slider').value"))
+            == 1.0
         )
         assert (
-                float(page.evaluate("document.getElementById('music-slider').value")) == 1.0
+            float(page.evaluate("document.getElementById('music-slider').value")) == 1.0
         )
         assert (
-                float(page.evaluate("document.getElementById('sfx-slider').value")) == 1.0
+            float(page.evaluate("document.getElementById('sfx-slider').value")) == 1.0
         )
         assert (
-                float(page.evaluate("document.getElementById('weapon-slider').value"))
-                == 1.0
+            float(page.evaluate("document.getElementById('weapon-slider').value"))
+            == 1.0
         )
         assert (
-                float(page.evaluate("document.getElementById('rotors-slider').value"))
-                == 1.0
+            float(page.evaluate("document.getElementById('rotors-slider').value"))
+            == 1.0
         )
         assert page.evaluate("document.getElementById('mute-master').checked")
         assert page.evaluate("document.getElementById('mute-music').checked")
@@ -232,7 +240,8 @@ def test_reset_flow(page: Page) -> None:
         # RESET-02: Reset does not duplicate sliders already default
         pre_reset_logs = len(logs)
         page.wait_for_function(
-            "() => typeof window.audioResetPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.audioResetPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.audioResetPressed([])")
         wait_for_console_log(
@@ -241,8 +250,8 @@ def test_reset_flow(page: Page) -> None:
         )
 
         assert (
-                float(page.evaluate("document.getElementById('master-slider').value"))
-                == 1.0
+            float(page.evaluate("document.getElementById('master-slider').value"))
+            == 1.0
         ), "Value changed unexpectedly"
 
         new_logs = logs[pre_reset_logs:]
@@ -265,17 +274,20 @@ def test_reset_flow(page: Page) -> None:
 
         # RESET-03: Reset after incomplete changes
         page.wait_for_function(
-            "() => typeof window.changeMasterVolume !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.changeMasterVolume !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.changeMasterVolume([0.4])")
         page.wait_for_function(
-            "() => typeof window.changeRotorsVolume !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.changeRotorsVolume !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.changeRotorsVolume([0.6])")
 
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.audioResetPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.audioResetPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.audioResetPressed([])")
         wait_for_console_log(
@@ -284,15 +296,15 @@ def test_reset_flow(page: Page) -> None:
         )
 
         assert (
-                float(page.evaluate("document.getElementById('master-slider').value"))
-                == 1.0
+            float(page.evaluate("document.getElementById('master-slider').value"))
+            == 1.0
         )
         assert (
-                float(page.evaluate("document.getElementById('rotors-slider').value"))
-                == 1.0
+            float(page.evaluate("document.getElementById('rotors-slider').value"))
+            == 1.0
         )
         assert (
-                float(page.evaluate("document.getElementById('music-slider').value")) == 1.0
+            float(page.evaluate("document.getElementById('music-slider').value")) == 1.0
         )
 
         new_logs = logs[pre_change_log_count:]
@@ -311,7 +323,8 @@ def test_reset_flow(page: Page) -> None:
 
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.audioResetPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.audioResetPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.audioResetPressed([])")
         wait_for_console_log(
@@ -334,19 +347,21 @@ def test_reset_flow(page: Page) -> None:
             timeout=TEST_TIMEOUT,
         )
         assert (
-                float(page.evaluate("document.getElementById('sfx-slider').value")) == 1.0
+            float(page.evaluate("document.getElementById('sfx-slider').value")) == 1.0
         ), "Reset not persisted after back"
 
         # RESET-05: Rapid Reset clicks
         page.wait_for_function(
-            "() => typeof window.changeMasterVolume !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.changeMasterVolume !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.changeMasterVolume([0.5])")
 
         pre_change_log_count = len(logs)
         for _ in range(3):
             page.wait_for_function(
-                "() => typeof window.audioResetPressed !== 'undefined'", timeout=TEST_TIMEOUT
+                "() => typeof window.audioResetPressed !== 'undefined'",
+                timeout=TEST_TIMEOUT,
             )
             page.evaluate("window.audioResetPressed([])")
 
@@ -356,8 +371,8 @@ def test_reset_flow(page: Page) -> None:
         )
 
         assert (
-                float(page.evaluate("document.getElementById('master-slider').value"))
-                == 1.0
+            float(page.evaluate("document.getElementById('master-slider').value"))
+            == 1.0
         )
 
         new_logs = logs[pre_change_log_count:]
@@ -373,7 +388,8 @@ def test_reset_flow(page: Page) -> None:
         # STATE-01: Reset button state persists in config
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.audioResetPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.audioResetPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.audioResetPressed([])")
         wait_for_console_log(
@@ -383,7 +399,9 @@ def test_reset_flow(page: Page) -> None:
 
         # Reload and validate persisted defaults for all audio controls
         page.reload(wait_until="networkidle")
-        page.wait_for_function("() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT)
+        page.wait_for_function(
+            "() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT
+        )
         page.wait_for_selector("#options-button", state="visible", timeout=TEST_TIMEOUT)
         page.wait_for_function(
             "() => typeof window.optionsPressed !== 'undefined'", timeout=TEST_TIMEOUT
@@ -402,22 +420,22 @@ def test_reset_flow(page: Page) -> None:
 
         # Sliders should all be at default volume
         assert (
-                float(page.evaluate("document.getElementById('master-slider').value"))
-                == 1.0
+            float(page.evaluate("document.getElementById('master-slider').value"))
+            == 1.0
         )
         assert (
-                float(page.evaluate("document.getElementById('music-slider').value")) == 1.0
+            float(page.evaluate("document.getElementById('music-slider').value")) == 1.0
         )
         assert (
-                float(page.evaluate("document.getElementById('sfx-slider').value")) == 1.0
+            float(page.evaluate("document.getElementById('sfx-slider').value")) == 1.0
         )
         assert (
-                float(page.evaluate("document.getElementById('weapon-slider').value"))
-                == 1.0
+            float(page.evaluate("document.getElementById('weapon-slider').value"))
+            == 1.0
         )
         assert (
-                float(page.evaluate("document.getElementById('rotors-slider').value"))
-                == 1.0
+            float(page.evaluate("document.getElementById('rotors-slider').value"))
+            == 1.0
         )
 
         # Mutes should retain their default checked state after reload
@@ -454,7 +472,8 @@ def test_reset_flow(page: Page) -> None:
         )
 
         page.wait_for_function(
-            "() => typeof window.audioResetPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.audioResetPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.audioResetPressed([])")
         wait_for_console_log(
@@ -472,8 +491,8 @@ def test_reset_flow(page: Page) -> None:
         )
 
         assert (
-                float(page.evaluate("document.getElementById('difficulty-slider').value"))
-                == initial_difficulty_value
+            float(page.evaluate("document.getElementById('difficulty-slider').value"))
+            == initial_difficulty_value
         ), "Difficulty reset unexpectedly"
 
     except Exception as e:
@@ -482,7 +501,7 @@ def test_reset_flow(page: Page) -> None:
         timestamp: int = int(time.time())
         page.screenshot(path=f"artifacts/test_reset_failure_screenshot_{timestamp}.png")
         with open(
-                f"artifacts/test_reset_failure_console_logs_{timestamp}.txt", "w"
+            f"artifacts/test_reset_failure_console_logs_{timestamp}.txt", "w"
         ) as f:
             for log in logs:
                 f.write(f"[{log['type']}] {log['text']}\n")

--- a/tests/reset_audio_flow_test.py
+++ b/tests/reset_audio_flow_test.py
@@ -28,11 +28,12 @@ v8_coverage_reset_flow_test.json, artifacts/test_reset_failure_*.png/txt
 import json
 import os
 import time
+from typing import Any, Callable
 
-from playwright.sync_api import Page
+import pytest
+from playwright.sync_api import Page, expect
 
 # Configuration for stability in different environments
-# Default to 5000ms, but allow CI to override via environment variable
 DEFAULT_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "30000"))
 TEST_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "5000"))
 
@@ -50,7 +51,7 @@ def test_reset_flow(page: Page) -> None:
     logs: list[dict[str, str]] = []
     cdp_session = None
 
-    def on_console(msg) -> None:
+    def on_console(msg: Any) -> None:
         """
         Console message handler to capture logs.
 
@@ -61,8 +62,22 @@ def test_reset_flow(page: Page) -> None:
         logs.append({"type": msg.type, "text": msg.text})
 
     page.on("console", on_console)
+
+    def wait_for_console_log(
+            predicate: Callable[[str], bool], start_idx: int, timeout_ms: int = TEST_TIMEOUT
+    ) -> None:
+        """
+        Helper to poll until a matching console log arrives or timeout expires.
+        """
+        start_time = time.time()
+        while (time.time() - start_time) * 1000 < timeout_ms:
+            if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
+                return
+            page.wait_for_timeout(50)  # Micro-poll for event loop progression
+        pytest.fail(f"Timed out waiting for expected console log matching predicate after {timeout_ms}ms")
+
     try:
-        # Start CDP session for V8 JS coverage (workaround for Python Playwright lacking native coverage API)
+        # Start CDP session for V8 JS coverage
         cdp_session = page.context.new_cdp_session(page)
         cdp_session.send("Profiler.enable")
         cdp_session.send(
@@ -74,22 +89,21 @@ def test_reset_flow(page: Page) -> None:
             wait_until="networkidle",
             timeout=DEFAULT_TIMEOUT,
         )
-        # 1. Wait for the engine to actually start the splash scene
-        page.wait_for_timeout(TEST_TIMEOUT)
-        page.wait_for_function("() => window.godotInitialized", timeout=DEFAULT_TIMEOUT)
+
+        # 1. Wait deterministically for Godot engine initialization
+        page.wait_for_function("() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT)
 
         # Verify canvas
         canvas = page.locator("canvas")
-        page.wait_for_selector("canvas", state="visible", timeout=DEFAULT_TIMEOUT)
+        expect(canvas).to_be_visible(timeout=DEFAULT_TIMEOUT)
         box: dict[str, float] | None = canvas.bounding_box()
         assert box is not None, "Canvas not found"
         assert "SkyLockAssault" in page.title(), "Title not found"
 
         # Open options
         page.wait_for_selector("#options-button", state="visible", timeout=TEST_TIMEOUT)
-        # page.click("#options-button", force=True)
         page.wait_for_function(
-            "window.optionsPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.optionsPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.optionsPressed([])")
 
@@ -97,28 +111,24 @@ def test_reset_flow(page: Page) -> None:
         page.wait_for_selector(
             "#advanced-button", state="visible", timeout=TEST_TIMEOUT
         )
-        # page.click("#advanced-button", force=True)
         page.wait_for_function(
-            "window.advancedPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.advancedPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.advancedPressed([])")
         page.wait_for_function(
-            "window.changeLogLevel !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.changeLogLevel !== 'undefined'", timeout=TEST_TIMEOUT
         )
-        advanced_display: str = page.evaluate(
-            "window.getComputedStyle(document.getElementById('log-level-select')).display"
+        page.wait_for_function(
+            "() => window.getComputedStyle(document.getElementById('log-level-select')).display === 'block'",
+            timeout=TEST_TIMEOUT,
         )
-        assert (
-            advanced_display == "block"
-        ), "Advanced menu not loaded (selected log level not displayed)"
 
         # Set log level DEBUG
         pre_change_log_count = len(logs)
         page.evaluate("window.changeLogLevel([0])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        new_logs = logs[pre_change_log_count:]
-        assert any(
-            "log level changed to: debug" in log["text"].lower() for log in new_logs
+        wait_for_console_log(
+            lambda text: "log level changed to: debug" in text,
+            start_idx=pre_change_log_count,
         )
         assert page.evaluate(
             "document.getElementById('audio-button') !== null"
@@ -128,9 +138,8 @@ def test_reset_flow(page: Page) -> None:
         page.wait_for_selector(
             "#advanced-back-button", state="visible", timeout=TEST_TIMEOUT
         )
-        # page.click("#advanced-back-button", force=True)
         page.wait_for_function(
-            "window.advancedBackPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.advancedBackPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.advancedBackPressed([])")
 
@@ -139,78 +148,79 @@ def test_reset_flow(page: Page) -> None:
         assert page.evaluate(
             "document.getElementById('audio-button') !== null"
         ), "Audio button not found/displayed"
+
         pre_change_log_count = len(logs)
-        # page.click("#audio-button", force=True)
         page.wait_for_function(
-            "window.audioPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.audioPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.audioPressed([])")
-        page.wait_for_timeout(TEST_TIMEOUT)  # Wait for audio scene load and JS eval
-        audio_display: str = page.evaluate(
-            "window.getComputedStyle(document.getElementById('master-slider')).display"
+
+        page.wait_for_function(
+            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'block'",
+            timeout=TEST_TIMEOUT,
         )
-        assert (
-            audio_display == "block"
-        ), "Audio menu not loaded (master-slider not displayed)"
-        new_logs = logs[pre_change_log_count:]
-        assert any(
-            "audio button pressed." in log["text"].lower() for log in new_logs
-        ), "Audio navigation log not found"
+        wait_for_console_log(
+            lambda text: "audio button pressed." in text,
+            start_idx=pre_change_log_count,
+        )
 
         # RESET-01: Reset all buses to defaults
-        # Preconditions: Sliders moved, some mutes active
-        # Steps: 1) Adjust multiple sliders 2) Toggle some mutes 3) Press Reset
-        # Expected: Every slider back to 1.0, all mutes off
         page.wait_for_function(
-            "window.changeMasterVolume !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.changeMasterVolume !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.changeMasterVolume([0.5])")
         page.wait_for_function(
-            "window.changeMusicVolume !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.changeMusicVolume !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.changeMusicVolume([0.3])")
         page.wait_for_function(
-            "window.changeSfxVolume !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.changeSfxVolume !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.changeSfxVolume([0.7])")
         page.wait_for_function(
-            "window.toggleMuteMusic !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteMusic !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.toggleMuteMusic([0])")
         page.wait_for_function(
-            "window.toggleMuteMaster !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteMaster !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.toggleMuteMaster([0])")
-        page.wait_for_timeout(TEST_TIMEOUT)
+
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "window.audioResetPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.audioResetPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.audioResetPressed([])")
-        page.wait_for_timeout(TEST_TIMEOUT)
+
+        wait_for_console_log(
+            lambda text: "audio volumes reset to defaults" in text,
+            start_idx=pre_change_log_count,
+        )
+
         assert (
-            float(page.evaluate("document.getElementById('master-slider').value"))
-            == 1.0
+                float(page.evaluate("document.getElementById('master-slider').value"))
+                == 1.0
         )
         assert (
-            float(page.evaluate("document.getElementById('music-slider').value")) == 1.0
+                float(page.evaluate("document.getElementById('music-slider').value")) == 1.0
         )
         assert (
-            float(page.evaluate("document.getElementById('sfx-slider').value")) == 1.0
+                float(page.evaluate("document.getElementById('sfx-slider').value")) == 1.0
         )
         assert (
-            float(page.evaluate("document.getElementById('weapon-slider').value"))
-            == 1.0
+                float(page.evaluate("document.getElementById('weapon-slider').value"))
+                == 1.0
         )
         assert (
-            float(page.evaluate("document.getElementById('rotors-slider').value"))
-            == 1.0
+                float(page.evaluate("document.getElementById('rotors-slider').value"))
+                == 1.0
         )
         assert page.evaluate("document.getElementById('mute-master').checked")
         assert page.evaluate("document.getElementById('mute-music').checked")
         assert page.evaluate("document.getElementById('mute-sfx').checked")
         assert page.evaluate("document.getElementById('mute-weapon').checked")
         assert page.evaluate("document.getElementById('mute-rotors').checked")
+
         new_logs = logs[pre_change_log_count:]
         assert any(
             "audio reset pressed" in log["text"].lower() for log in new_logs
@@ -220,18 +230,19 @@ def test_reset_flow(page: Page) -> None:
         ), "Reset log not found"
 
         # RESET-02: Reset does not duplicate sliders already default
-        # Preconditions: All at defaults
-        # Steps: Press Reset
-        # Expected: No change, UI stable
         pre_reset_logs = len(logs)
         page.wait_for_function(
-            "window.audioResetPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.audioResetPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.audioResetPressed([])")
-        page.wait_for_timeout(TEST_TIMEOUT)
+        wait_for_console_log(
+            lambda text: "audio volumes reset to defaults" in text,
+            start_idx=pre_reset_logs,
+        )
+
         assert (
-            float(page.evaluate("document.getElementById('master-slider').value"))
-            == 1.0
+                float(page.evaluate("document.getElementById('master-slider').value"))
+                == 1.0
         ), "Value changed unexpectedly"
 
         new_logs = logs[pre_reset_logs:]
@@ -253,35 +264,37 @@ def test_reset_flow(page: Page) -> None:
         ), f"Unexpected error after reset on defaults: {actual_errors}"
 
         # RESET-03: Reset after incomplete changes
-        # Preconditions: Only Master & Rotors changed
-        # Steps: Press Reset
-        # Expected: All buses at defaults
         page.wait_for_function(
-            "window.changeMasterVolume !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.changeMasterVolume !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.changeMasterVolume([0.4])")
         page.wait_for_function(
-            "window.changeRotorsVolume !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.changeRotorsVolume !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.changeRotorsVolume([0.6])")
-        page.wait_for_timeout(TEST_TIMEOUT)
+
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "window.audioResetPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.audioResetPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.audioResetPressed([])")
-        page.wait_for_timeout(TEST_TIMEOUT)
+        wait_for_console_log(
+            lambda text: "audio volumes reset to defaults" in text,
+            start_idx=pre_change_log_count,
+        )
+
         assert (
-            float(page.evaluate("document.getElementById('master-slider').value"))
-            == 1.0
+                float(page.evaluate("document.getElementById('master-slider').value"))
+                == 1.0
         )
         assert (
-            float(page.evaluate("document.getElementById('rotors-slider').value"))
-            == 1.0
+                float(page.evaluate("document.getElementById('rotors-slider').value"))
+                == 1.0
         )
         assert (
-            float(page.evaluate("document.getElementById('music-slider').value")) == 1.0
-        )  # Unchanged remains default
+                float(page.evaluate("document.getElementById('music-slider').value")) == 1.0
+        )
+
         new_logs = logs[pre_change_log_count:]
         assert any(
             "audio reset pressed" in log["text"].lower() for log in new_logs
@@ -291,66 +304,63 @@ def test_reset_flow(page: Page) -> None:
         ), "Reset log not found"
 
         # RESET-04: Reset persists after Back navigation
-        # Preconditions: Modified then Reset
-        # Steps: Back → Re-enter Audio
-        # Expected: Defaults remain
         page.wait_for_function(
-            "window.changeSfxVolume !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.changeSfxVolume !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.changeSfxVolume([0.2])")
+
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "window.audioResetPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.audioResetPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.audioResetPressed([])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        new_logs = logs[pre_change_log_count:]
-        assert any(
-            "audio reset pressed" in log["text"].lower() for log in new_logs
-        ), "Reset log not found"
-        assert any(
-            "audio volumes reset to defaults" in log["text"].lower() for log in new_logs
-        ), "Reset log not found"
+        wait_for_console_log(
+            lambda text: "audio volumes reset to defaults" in text,
+            start_idx=pre_change_log_count,
+        )
+
+        page.wait_for_function(
+            "() => typeof window.audioBackPressed !== 'undefined'", timeout=TEST_TIMEOUT
+        )
         page.evaluate("window.audioBackPressed([])")
         page.wait_for_selector("#audio-button", state="visible", timeout=TEST_TIMEOUT)
-        # page.click("#audio-button", force=True)
         page.wait_for_function(
-            "window.audioPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.audioPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.audioPressed([0])")
-        page.wait_for_timeout(TEST_TIMEOUT)
+
+        page.wait_for_function(
+            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'block'",
+            timeout=TEST_TIMEOUT,
+        )
         assert (
-            float(page.evaluate("document.getElementById('sfx-slider').value")) == 1.0
+                float(page.evaluate("document.getElementById('sfx-slider').value")) == 1.0
         ), "Reset not persisted after back"
 
         # RESET-05: Rapid Reset clicks
-        # Preconditions: Controls modified
-        # Steps: Click Reset quickly 3×
-        # Expected: UI stays stable with defaults, no JS errors
         page.wait_for_function(
-            "window.changeMasterVolume !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.changeMasterVolume !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.changeMasterVolume([0.5])")
-        page.wait_for_timeout(TEST_TIMEOUT)
+
         pre_change_log_count = len(logs)
         for _ in range(3):
             page.wait_for_function(
-                "window.audioResetPressed !== undefined", timeout=TEST_TIMEOUT
+                "() => typeof window.audioResetPressed !== 'undefined'", timeout=TEST_TIMEOUT
             )
             page.evaluate("window.audioResetPressed([])")
-            page.wait_for_timeout(TEST_TIMEOUT)  # Rapid
+
+        wait_for_console_log(
+            lambda text: "audio volumes reset to defaults" in text,
+            start_idx=pre_change_log_count,
+        )
+
         assert (
-            float(page.evaluate("document.getElementById('master-slider').value"))
-            == 1.0
+                float(page.evaluate("document.getElementById('master-slider').value"))
+                == 1.0
         )
 
         new_logs = logs[pre_change_log_count:]
-        ignored_phrases = [
-            "encryption aborted",
-            "salt is empty",
-            "key generation failed",
-        ]
-
         actual_errors = []
         for log in new_logs:
             text = log["text"].lower()
@@ -361,59 +371,53 @@ def test_reset_flow(page: Page) -> None:
         assert not actual_errors, f"JS errors during rapid reset: {actual_errors}"
 
         # STATE-01: Reset button state persists in config
-        # Preconditions: After Reset + Save
-        # Steps: Reload game/settings
-        # Expected: Defaults retained for all sliders and mutes
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "window.audioResetPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.audioResetPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.audioResetPressed([])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        new_logs = logs[pre_change_log_count:]
-        assert any(
-            "audio reset pressed" in log["text"].lower() for log in new_logs
-        ), "Reset log not found"
-        assert any(
-            "audio volumes reset to defaults" in log["text"].lower() for log in new_logs
-        ), "Reset log not found"
+        wait_for_console_log(
+            lambda text: "audio volumes reset to defaults" in text,
+            start_idx=pre_change_log_count,
+        )
 
         # Reload and validate persisted defaults for all audio controls
-        page.reload()
-        page.wait_for_timeout(DEFAULT_TIMEOUT)
-        page.wait_for_function("() => window.godotInitialized", timeout=TEST_TIMEOUT)
+        page.reload(wait_until="networkidle")
+        page.wait_for_function("() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT)
         page.wait_for_selector("#options-button", state="visible", timeout=TEST_TIMEOUT)
         page.wait_for_function(
-            "window.optionsPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.optionsPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
-        # page.click("#options-button", force=True)
         page.evaluate("window.optionsPressed([])")
         page.wait_for_selector("#audio-button", state="visible", timeout=TEST_TIMEOUT)
-        # page.click("#audio-button", force=True)
         page.wait_for_function(
-            "window.audioPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.audioPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.audioPressed([])")
-        page.wait_for_timeout(TEST_TIMEOUT)
 
-        # Sliders should all be at default volume (mirroring RESET-01 expectations)
+        page.wait_for_function(
+            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'block'",
+            timeout=TEST_TIMEOUT,
+        )
+
+        # Sliders should all be at default volume
         assert (
-            float(page.evaluate("document.getElementById('master-slider').value"))
-            == 1.0
+                float(page.evaluate("document.getElementById('master-slider').value"))
+                == 1.0
         )
         assert (
-            float(page.evaluate("document.getElementById('music-slider').value")) == 1.0
+                float(page.evaluate("document.getElementById('music-slider').value")) == 1.0
         )
         assert (
-            float(page.evaluate("document.getElementById('sfx-slider').value")) == 1.0
+                float(page.evaluate("document.getElementById('sfx-slider').value")) == 1.0
         )
         assert (
-            float(page.evaluate("document.getElementById('weapon-slider').value"))
-            == 1.0
+                float(page.evaluate("document.getElementById('weapon-slider').value"))
+                == 1.0
         )
         assert (
-            float(page.evaluate("document.getElementById('rotors-slider').value"))
-            == 1.0
+                float(page.evaluate("document.getElementById('rotors-slider').value"))
+                == 1.0
         )
 
         # Mutes should retain their default checked state after reload
@@ -424,59 +428,61 @@ def test_reset_flow(page: Page) -> None:
         assert page.evaluate("document.getElementById('mute-rotors').checked")
 
         # STATE-02: Reset doesn't affect other menus
-        # Preconditions: Reset in Audio
-        # Steps: Navigate other menus
-        # Expected: Other menus unaffected
-        # Navigate back to options menu to access difficulty-slider
         page.wait_for_function(
-            "window.audioBackPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.audioBackPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.audioBackPressed([])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        # Cache the initial difficulty value to avoid depending on a hardcoded default
+        page.wait_for_function(
+            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'none'",
+            timeout=TEST_TIMEOUT,
+        )
+
         initial_difficulty_value = float(
             page.evaluate("document.getElementById('difficulty-slider').value")
         )
         pre_change_log_count = len(logs)
         assert initial_difficulty_value == 1.0, "Unexpected initial difficulty default"
-        # Navigate back to audio menu to test reset isolation
+
         page.wait_for_selector("#audio-button", state="visible", timeout=TEST_TIMEOUT)
-        # page.click("#audio-button", force=True)
         page.wait_for_function(
-            "window.audioPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.audioPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.audioPressed([])")
-        page.wait_for_timeout(TEST_TIMEOUT)
         page.wait_for_function(
-            "window.audioResetPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'block'",
+            timeout=TEST_TIMEOUT,
+        )
+
+        page.wait_for_function(
+            "() => typeof window.audioResetPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.audioResetPressed([])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        new_logs = logs[pre_change_log_count:]
-        assert any(
-            "audio reset pressed" in log["text"].lower() for log in new_logs
-        ), "Reset log not found"
-        assert any(
-            "audio volumes reset to defaults" in log["text"].lower() for log in new_logs
-        ), "Reset log not found"
+        wait_for_console_log(
+            lambda text: "audio volumes reset to defaults" in text,
+            start_idx=pre_change_log_count,
+        )
+
         page.wait_for_function(
-            "window.audioBackPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.audioBackPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.audioBackPressed([])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        # Later, after audio reset and navigating back to the difficulty menu,
-        # assert the difficulty slider has not changed from its initial value.
+        page.wait_for_function(
+            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'none'",
+            timeout=TEST_TIMEOUT,
+        )
+
         assert (
-            float(page.evaluate("document.getElementById('difficulty-slider').value"))
-            == initial_difficulty_value
+                float(page.evaluate("document.getElementById('difficulty-slider').value"))
+                == initial_difficulty_value
         ), "Difficulty reset unexpectedly"
+
     except Exception as e:
         print(f"Test suite failed: {str(e)}")
         os.makedirs("artifacts", exist_ok=True)
         timestamp: int = int(time.time())
         page.screenshot(path=f"artifacts/test_reset_failure_screenshot_{timestamp}.png")
         with open(
-            f"artifacts/test_reset_failure_console_logs_{timestamp}.txt", "w"
+                f"artifacts/test_reset_failure_console_logs_{timestamp}.txt", "w"
         ) as f:
             for log in logs:
                 f.write(f"[{log['type']}] {log['text']}\n")

--- a/tests/reset_audio_flow_test.py
+++ b/tests/reset_audio_flow_test.py
@@ -40,6 +40,42 @@ DEFAULT_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "30000"))
 TEST_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "5000"))
 
 
+def wait_for_console_log(
+    logs: list[dict[str, str]],
+    predicate: Callable[[str], bool],
+    start_idx: int,
+    page: Page,
+    timeout_ms: int = TEST_TIMEOUT,
+) -> None:
+    """Helper to poll until a matching console log arrives or timeout expires."""
+    start_time = time.time()
+    while (time.time() - start_time) * 1000 < timeout_ms:
+        if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
+            return
+        page.wait_for_timeout(50)  # Micro-poll for event loop progression
+    pytest.fail(
+        "Timed out waiting for expected console log matching "
+        f"predicate after {timeout_ms}ms"
+    )
+
+
+def _has_log(logs: list[dict[str, str]], keyword: str) -> bool:
+    """Check if any log entry contains the specified keyword."""
+    return any(keyword in log["text"].lower() for log in logs)
+
+
+def _get_unignored_errors(
+    logs_subset: list[dict[str, str]], ignored_phrases: list[str]
+) -> list[str]:
+    """Extract error messages from logs excluding ignored phrases."""
+    actual_errors = []
+    for log in logs_subset:
+        text = log["text"].lower()
+        if "error" in text and not any(ignored in text for ignored in ignored_phrases):
+            actual_errors.append(log["text"])
+    return actual_errors
+
+
 def test_reset_flow(page: Page) -> None:
     """
     Main test suite for reset functionality using DOM overlays.
@@ -65,21 +101,11 @@ def test_reset_flow(page: Page) -> None:
 
     page.on("console", on_console)
 
-    def wait_for_console_log(
-        predicate: Callable[[str], bool],
-        start_idx: int,
-        timeout_ms: int = TEST_TIMEOUT,
-    ) -> None:
-        """Helper to poll until a matching console log arrives or timeout expires."""
-        start_time = time.time()
-        while (time.time() - start_time) * 1000 < timeout_ms:
-            if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
-                return
-            page.wait_for_timeout(50)  # Micro-poll for event loop progression
-        pytest.fail(
-            "Timed out waiting for expected console log matching "
-            f"predicate after {timeout_ms}ms"
-        )
+    ignored_phrases = [
+        "encryption aborted",
+        "salt is empty",
+        "key generation failed",
+    ]
 
     try:
         # Start CDP session for V8 JS coverage
@@ -108,9 +134,12 @@ def test_reset_flow(page: Page) -> None:
         assert "SkyLockAssault" in page.title(), "Title not found"
 
         # Open options
-        page.wait_for_selector("#options-button", state="visible", timeout=TEST_TIMEOUT)
+        page.wait_for_selector(
+            "#options-button", state="visible", timeout=TEST_TIMEOUT
+        )
         page.wait_for_function(
-            "() => typeof window.optionsPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.optionsPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.optionsPressed([])")
 
@@ -119,11 +148,13 @@ def test_reset_flow(page: Page) -> None:
             "#advanced-button", state="visible", timeout=TEST_TIMEOUT
         )
         page.wait_for_function(
-            "() => typeof window.advancedPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.advancedPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.advancedPressed([])")
         page.wait_for_function(
-            "() => typeof window.changeLogLevel !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.changeLogLevel !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.wait_for_function(
             "() => window.getComputedStyle("
@@ -136,8 +167,10 @@ def test_reset_flow(page: Page) -> None:
         pre_change_log_count = len(logs)
         page.evaluate("window.changeLogLevel([0])")
         wait_for_console_log(
+            logs,
             lambda text: "log level changed to: debug" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
         assert page.evaluate(
             "document.getElementById('audio-button') !== null"
@@ -154,14 +187,17 @@ def test_reset_flow(page: Page) -> None:
         page.evaluate("window.advancedBackPressed([])")
 
         # Navigate to audio sub-menu
-        page.wait_for_selector("#audio-button", state="visible", timeout=TEST_TIMEOUT)
+        page.wait_for_selector(
+            "#audio-button", state="visible", timeout=TEST_TIMEOUT
+        )
         assert page.evaluate(
             "document.getElementById('audio-button') !== null"
         ), "Audio button not found/displayed"
 
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.audioPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.audioPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.audioPressed([])")
 
@@ -172,8 +208,10 @@ def test_reset_flow(page: Page) -> None:
             timeout=TEST_TIMEOUT,
         )
         wait_for_console_log(
+            logs,
             lambda text: "audio button pressed." in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
 
         # RESET-01: Reset all buses to defaults
@@ -188,15 +226,18 @@ def test_reset_flow(page: Page) -> None:
         )
         page.evaluate("window.changeMusicVolume([0.3])")
         page.wait_for_function(
-            "() => typeof window.changeSfxVolume !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.changeSfxVolume !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.changeSfxVolume([0.7])")
         page.wait_for_function(
-            "() => typeof window.toggleMuteMusic !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteMusic !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.toggleMuteMusic([0])")
         page.wait_for_function(
-            "() => typeof window.toggleMuteMaster !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteMaster !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.toggleMuteMaster([0])")
 
@@ -208,8 +249,10 @@ def test_reset_flow(page: Page) -> None:
         page.evaluate("window.audioResetPressed([])")
 
         wait_for_console_log(
+            logs,
             lambda text: "audio volumes reset to defaults" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
 
         assert (
@@ -217,10 +260,12 @@ def test_reset_flow(page: Page) -> None:
             == 1.0
         )
         assert (
-            float(page.evaluate("document.getElementById('music-slider').value")) == 1.0
+            float(page.evaluate("document.getElementById('music-slider').value"))
+            == 1.0
         )
         assert (
-            float(page.evaluate("document.getElementById('sfx-slider').value")) == 1.0
+            float(page.evaluate("document.getElementById('sfx-slider').value"))
+            == 1.0
         )
         assert (
             float(page.evaluate("document.getElementById('weapon-slider').value"))
@@ -237,11 +282,9 @@ def test_reset_flow(page: Page) -> None:
         assert page.evaluate("document.getElementById('mute-rotors').checked")
 
         new_logs = logs[pre_change_log_count:]
-        assert any(
-            "audio reset pressed" in log["text"].lower() for log in new_logs
-        ), "Reset log not found"
-        assert any(
-            "audio volumes reset to defaults" in log["text"].lower() for log in new_logs
+        assert _has_log(new_logs, "audio reset pressed"), "Reset log not found"
+        assert _has_log(
+            new_logs, "audio volumes reset to defaults"
         ), "Reset log not found"
 
         # RESET-02: Reset does not duplicate sliders already default
@@ -252,8 +295,10 @@ def test_reset_flow(page: Page) -> None:
         )
         page.evaluate("window.audioResetPressed([])")
         wait_for_console_log(
+            logs,
             lambda text: "audio volumes reset to defaults" in text,
-            start_idx=pre_reset_logs,
+            pre_reset_logs,
+            page,
         )
 
         assert (
@@ -261,20 +306,9 @@ def test_reset_flow(page: Page) -> None:
             == 1.0
         ), "Value changed unexpectedly"
 
-        new_logs = logs[pre_reset_logs:]
-        ignored_phrases = [
-            "encryption aborted",
-            "salt is empty",
-            "key generation failed",
-        ]
-
-        actual_errors = []
-        for log in new_logs:
-            text = log["text"].lower()
-            if "error" in text:
-                if not any(ignored in text for ignored in ignored_phrases):
-                    actual_errors.append(log["text"])
-
+        actual_errors = _get_unignored_errors(
+            logs[pre_reset_logs:], ignored_phrases
+        )
         assert (
             not actual_errors
         ), f"Unexpected error after reset on defaults: {actual_errors}"
@@ -298,8 +332,10 @@ def test_reset_flow(page: Page) -> None:
         )
         page.evaluate("window.audioResetPressed([])")
         wait_for_console_log(
+            logs,
             lambda text: "audio volumes reset to defaults" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
 
         assert (
@@ -311,26 +347,28 @@ def test_reset_flow(page: Page) -> None:
             == 1.0
         )
         assert (
-            float(page.evaluate("document.getElementById('music-slider').value")) == 1.0
+            float(page.evaluate("document.getElementById('music-slider').value"))
+            == 1.0
         )
 
         new_logs = logs[pre_change_log_count:]
-        assert any(
-            "audio reset pressed" in log["text"].lower() for log in new_logs
-        ), "Reset log not found"
-        assert any(
-            "audio volumes reset to defaults" in log["text"].lower() for log in new_logs
+        assert _has_log(new_logs, "audio reset pressed"), "Reset log not found"
+        assert _has_log(
+            new_logs, "audio volumes reset to defaults"
         ), "Reset log not found"
 
         # RESET-04: Reset persists after Back navigation
         pre_sfx_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.changeSfxVolume !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.changeSfxVolume !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.changeSfxVolume([0.2])")
         wait_for_console_log(
+            logs,
             lambda text: "applied loaded sfx volume to audioserver: 0.2" in text,
-            start_idx=pre_sfx_count,
+            pre_sfx_count,
+            page,
         )
         page.wait_for_function(
             "() => parseFloat(document.getElementById('sfx-slider').value) === 0.2",
@@ -344,21 +382,29 @@ def test_reset_flow(page: Page) -> None:
         )
         page.evaluate("window.audioResetPressed([])")
         wait_for_console_log(
+            logs,
             lambda text: "audio volumes reset to defaults" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
         page.wait_for_function(
-            "() => parseFloat(document.getElementById('sfx-slider').value) === 1.0",
+            "() => parseFloat("
+            "document.getElementById('sfx-slider').value"
+            ") === 1.0",
             timeout=TEST_TIMEOUT,
         )
 
         page.wait_for_function(
-            "() => typeof window.audioBackPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.audioBackPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.audioBackPressed([])")
-        page.wait_for_selector("#audio-button", state="visible", timeout=TEST_TIMEOUT)
+        page.wait_for_selector(
+            "#audio-button", state="visible", timeout=TEST_TIMEOUT
+        )
         page.wait_for_function(
-            "() => typeof window.audioPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.audioPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.audioPressed([0])")
 
@@ -369,7 +415,8 @@ def test_reset_flow(page: Page) -> None:
             timeout=TEST_TIMEOUT,
         )
         assert (
-            float(page.evaluate("document.getElementById('sfx-slider').value")) == 1.0
+            float(page.evaluate("document.getElementById('sfx-slider').value"))
+            == 1.0
         ), "Reset not persisted after back"
 
         # RESET-05: Rapid Reset clicks
@@ -388,8 +435,10 @@ def test_reset_flow(page: Page) -> None:
             page.evaluate("window.audioResetPressed([])")
 
         wait_for_console_log(
+            logs,
             lambda text: "audio volumes reset to defaults" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
 
         assert (
@@ -397,14 +446,9 @@ def test_reset_flow(page: Page) -> None:
             == 1.0
         )
 
-        new_logs = logs[pre_change_log_count:]
-        actual_errors = []
-        for log in new_logs:
-            text = log["text"].lower()
-            if "error" in text:
-                if not any(ignored in text for ignored in ignored_phrases):
-                    actual_errors.append(log["text"])
-
+        actual_errors = _get_unignored_errors(
+            logs[pre_change_log_count:], ignored_phrases
+        )
         assert not actual_errors, f"JS errors during rapid reset: {actual_errors}"
 
         # STATE-01: Reset button state persists in config
@@ -415,11 +459,15 @@ def test_reset_flow(page: Page) -> None:
         )
         page.evaluate("window.audioResetPressed([])")
         wait_for_console_log(
+            logs,
             lambda text: "audio volumes reset to defaults" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
         page.wait_for_function(
-            "() => parseFloat(document.getElementById('sfx-slider').value) === 1.0",
+            "() => parseFloat("
+            "document.getElementById('sfx-slider').value"
+            ") === 1.0",
             timeout=TEST_TIMEOUT,
         )
 
@@ -428,14 +476,20 @@ def test_reset_flow(page: Page) -> None:
         page.wait_for_function(
             "() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT
         )
-        page.wait_for_selector("#options-button", state="visible", timeout=TEST_TIMEOUT)
+        page.wait_for_selector(
+            "#options-button", state="visible", timeout=TEST_TIMEOUT
+        )
         page.wait_for_function(
-            "() => typeof window.optionsPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.optionsPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.optionsPressed([])")
-        page.wait_for_selector("#audio-button", state="visible", timeout=TEST_TIMEOUT)
+        page.wait_for_selector(
+            "#audio-button", state="visible", timeout=TEST_TIMEOUT
+        )
         page.wait_for_function(
-            "() => typeof window.audioPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.audioPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.audioPressed([])")
 
@@ -452,10 +506,12 @@ def test_reset_flow(page: Page) -> None:
             == 1.0
         )
         assert (
-            float(page.evaluate("document.getElementById('music-slider').value")) == 1.0
+            float(page.evaluate("document.getElementById('music-slider').value"))
+            == 1.0
         )
         assert (
-            float(page.evaluate("document.getElementById('sfx-slider').value")) == 1.0
+            float(page.evaluate("document.getElementById('sfx-slider').value"))
+            == 1.0
         )
         assert (
             float(page.evaluate("document.getElementById('weapon-slider').value"))
@@ -475,7 +531,8 @@ def test_reset_flow(page: Page) -> None:
 
         # STATE-02: Reset doesn't affect other menus
         page.wait_for_function(
-            "() => typeof window.audioBackPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.audioBackPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.audioBackPressed([])")
         page.wait_for_function(
@@ -491,9 +548,12 @@ def test_reset_flow(page: Page) -> None:
         pre_change_log_count = len(logs)
         assert initial_difficulty_value == 1.0, "Unexpected initial difficulty default"
 
-        page.wait_for_selector("#audio-button", state="visible", timeout=TEST_TIMEOUT)
+        page.wait_for_selector(
+            "#audio-button", state="visible", timeout=TEST_TIMEOUT
+        )
         page.wait_for_function(
-            "() => typeof window.audioPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.audioPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.audioPressed([])")
         page.wait_for_function(
@@ -509,12 +569,15 @@ def test_reset_flow(page: Page) -> None:
         )
         page.evaluate("window.audioResetPressed([])")
         wait_for_console_log(
+            logs,
             lambda text: "audio volumes reset to defaults" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
 
         page.wait_for_function(
-            "() => typeof window.audioBackPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.audioBackPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.audioBackPressed([])")
         page.wait_for_function(
@@ -525,7 +588,11 @@ def test_reset_flow(page: Page) -> None:
         )
 
         assert (
-            float(page.evaluate("document.getElementById('difficulty-slider').value"))
+            float(
+                page.evaluate(
+                    "document.getElementById('difficulty-slider').value"
+                )
+            )
             == initial_difficulty_value
         ), "Difficulty reset unexpectedly"
 
@@ -533,7 +600,9 @@ def test_reset_flow(page: Page) -> None:
         print(f"Test suite failed: {str(e)}")
         os.makedirs("artifacts", exist_ok=True)
         timestamp: int = int(time.time())
-        page.screenshot(path=f"artifacts/test_reset_failure_screenshot_{timestamp}.png")
+        page.screenshot(
+            path=f"artifacts/test_reset_failure_screenshot_{timestamp}.png"
+        )
         with open(
             f"artifacts/test_reset_failure_console_logs_{timestamp}.txt", "w"
         ) as f:

--- a/tests/reset_audio_flow_test.py
+++ b/tests/reset_audio_flow_test.py
@@ -134,9 +134,7 @@ def test_reset_flow(page: Page) -> None:
         assert "SkyLockAssault" in page.title(), "Title not found"
 
         # Open options
-        page.wait_for_selector(
-            "#options-button", state="visible", timeout=TEST_TIMEOUT
-        )
+        page.wait_for_selector("#options-button", state="visible", timeout=TEST_TIMEOUT)
         page.wait_for_function(
             "() => typeof window.optionsPressed !== 'undefined'",
             timeout=TEST_TIMEOUT,
@@ -187,9 +185,7 @@ def test_reset_flow(page: Page) -> None:
         page.evaluate("window.advancedBackPressed([])")
 
         # Navigate to audio sub-menu
-        page.wait_for_selector(
-            "#audio-button", state="visible", timeout=TEST_TIMEOUT
-        )
+        page.wait_for_selector("#audio-button", state="visible", timeout=TEST_TIMEOUT)
         assert page.evaluate(
             "document.getElementById('audio-button') !== null"
         ), "Audio button not found/displayed"
@@ -260,12 +256,10 @@ def test_reset_flow(page: Page) -> None:
             == 1.0
         )
         assert (
-            float(page.evaluate("document.getElementById('music-slider').value"))
-            == 1.0
+            float(page.evaluate("document.getElementById('music-slider').value")) == 1.0
         )
         assert (
-            float(page.evaluate("document.getElementById('sfx-slider').value"))
-            == 1.0
+            float(page.evaluate("document.getElementById('sfx-slider').value")) == 1.0
         )
         assert (
             float(page.evaluate("document.getElementById('weapon-slider').value"))
@@ -306,9 +300,7 @@ def test_reset_flow(page: Page) -> None:
             == 1.0
         ), "Value changed unexpectedly"
 
-        actual_errors = _get_unignored_errors(
-            logs[pre_reset_logs:], ignored_phrases
-        )
+        actual_errors = _get_unignored_errors(logs[pre_reset_logs:], ignored_phrases)
         assert (
             not actual_errors
         ), f"Unexpected error after reset on defaults: {actual_errors}"
@@ -347,8 +339,7 @@ def test_reset_flow(page: Page) -> None:
             == 1.0
         )
         assert (
-            float(page.evaluate("document.getElementById('music-slider').value"))
-            == 1.0
+            float(page.evaluate("document.getElementById('music-slider').value")) == 1.0
         )
 
         new_logs = logs[pre_change_log_count:]
@@ -399,9 +390,7 @@ def test_reset_flow(page: Page) -> None:
             timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.audioBackPressed([])")
-        page.wait_for_selector(
-            "#audio-button", state="visible", timeout=TEST_TIMEOUT
-        )
+        page.wait_for_selector("#audio-button", state="visible", timeout=TEST_TIMEOUT)
         page.wait_for_function(
             "() => typeof window.audioPressed !== 'undefined'",
             timeout=TEST_TIMEOUT,
@@ -415,8 +404,7 @@ def test_reset_flow(page: Page) -> None:
             timeout=TEST_TIMEOUT,
         )
         assert (
-            float(page.evaluate("document.getElementById('sfx-slider').value"))
-            == 1.0
+            float(page.evaluate("document.getElementById('sfx-slider').value")) == 1.0
         ), "Reset not persisted after back"
 
         # RESET-05: Rapid Reset clicks
@@ -476,17 +464,13 @@ def test_reset_flow(page: Page) -> None:
         page.wait_for_function(
             "() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT
         )
-        page.wait_for_selector(
-            "#options-button", state="visible", timeout=TEST_TIMEOUT
-        )
+        page.wait_for_selector("#options-button", state="visible", timeout=TEST_TIMEOUT)
         page.wait_for_function(
             "() => typeof window.optionsPressed !== 'undefined'",
             timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.optionsPressed([])")
-        page.wait_for_selector(
-            "#audio-button", state="visible", timeout=TEST_TIMEOUT
-        )
+        page.wait_for_selector("#audio-button", state="visible", timeout=TEST_TIMEOUT)
         page.wait_for_function(
             "() => typeof window.audioPressed !== 'undefined'",
             timeout=TEST_TIMEOUT,
@@ -506,12 +490,10 @@ def test_reset_flow(page: Page) -> None:
             == 1.0
         )
         assert (
-            float(page.evaluate("document.getElementById('music-slider').value"))
-            == 1.0
+            float(page.evaluate("document.getElementById('music-slider').value")) == 1.0
         )
         assert (
-            float(page.evaluate("document.getElementById('sfx-slider').value"))
-            == 1.0
+            float(page.evaluate("document.getElementById('sfx-slider').value")) == 1.0
         )
         assert (
             float(page.evaluate("document.getElementById('weapon-slider').value"))
@@ -548,9 +530,7 @@ def test_reset_flow(page: Page) -> None:
         pre_change_log_count = len(logs)
         assert initial_difficulty_value == 1.0, "Unexpected initial difficulty default"
 
-        page.wait_for_selector(
-            "#audio-button", state="visible", timeout=TEST_TIMEOUT
-        )
+        page.wait_for_selector("#audio-button", state="visible", timeout=TEST_TIMEOUT)
         page.wait_for_function(
             "() => typeof window.audioPressed !== 'undefined'",
             timeout=TEST_TIMEOUT,
@@ -588,11 +568,7 @@ def test_reset_flow(page: Page) -> None:
         )
 
         assert (
-            float(
-                page.evaluate(
-                    "document.getElementById('difficulty-slider').value"
-                )
-            )
+            float(page.evaluate("document.getElementById('difficulty-slider').value"))
             == initial_difficulty_value
         ), "Difficulty reset unexpectedly"
 
@@ -600,9 +576,7 @@ def test_reset_flow(page: Page) -> None:
         print(f"Test suite failed: {str(e)}")
         os.makedirs("artifacts", exist_ok=True)
         timestamp: int = int(time.time())
-        page.screenshot(
-            path=f"artifacts/test_reset_failure_screenshot_{timestamp}.png"
-        )
+        page.screenshot(path=f"artifacts/test_reset_failure_screenshot_{timestamp}.png")
         with open(
             f"artifacts/test_reset_failure_console_logs_{timestamp}.txt", "w"
         ) as f:

--- a/tests/reset_audio_flow_test.py
+++ b/tests/reset_audio_flow_test.py
@@ -1,15 +1,17 @@
 # Copyright (C) 2025 Egor Kostan
 # SPDX-License-Identifier: GPL-3.0-or-later
-# tests/reset_flow_test.py
+# tests/reset_audio_flow_test.py
 """
 Reset Functionality Test Suite (Playwright + UI Automation with DOM Overlays)
 ============================================================================
 
 Overview
 --------
-E2E tests for RESET-01 to RESET-05 and STATE-01 to STATE-02: Validate reset button behavior in audio menu, including defaults restoration, no-op on defaults, partial changes, persistence after navigation/reload, rapid clicks, and isolation to audio menu.
+E2E tests for RESET-01 to RESET-05 and STATE-01 to STATE-02: Validate reset button
+behavior in audio menu, including defaults restoration, no-op on defaults, partial
+changes, persistence after navigation/reload, rapid clicks, and isolation.
 
-Navigates to audio menu, adjusts sliders/mutes, resets, verifies states/logs. For STATE-01, reloads page to check persistence (assumes config saves on reset; if not, adjust assertions).
+Navigates to audio menu, adjusts sliders/mutes, resets, verifies states/logs.
 
 Prerequisites
 -------------
@@ -42,7 +44,7 @@ def test_reset_flow(page: Page) -> None:
     """
     Main test suite for reset functionality using DOM overlays.
 
-    Implements RESET-01 to RESET-05 and STATE-01 to STATE-02: Adjust/reset, verify defaults, persistence, stability.
+    Implements RESET-01 to RESET-05 and STATE-01 to STATE-02.
 
     :param page: The Playwright page object.
     :type page: Page
@@ -64,18 +66,19 @@ def test_reset_flow(page: Page) -> None:
     page.on("console", on_console)
 
     def wait_for_console_log(
-        predicate: Callable[[str], bool], start_idx: int, timeout_ms: int = TEST_TIMEOUT
+        predicate: Callable[[str], bool],
+        start_idx: int,
+        timeout_ms: int = TEST_TIMEOUT,
     ) -> None:
-        """
-        Helper to poll until a matching console log arrives or timeout expires.
-        """
+        """Helper to poll until a matching console log arrives or timeout expires."""
         start_time = time.time()
         while (time.time() - start_time) * 1000 < timeout_ms:
             if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
                 return
             page.wait_for_timeout(50)  # Micro-poll for event loop progression
         pytest.fail(
-            f"Timed out waiting for expected console log matching predicate after {timeout_ms}ms"
+            "Timed out waiting for expected console log matching "
+            f"predicate after {timeout_ms}ms"
         )
 
     try:
@@ -123,7 +126,9 @@ def test_reset_flow(page: Page) -> None:
             "() => typeof window.changeLogLevel !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.wait_for_function(
-            "() => window.getComputedStyle(document.getElementById('log-level-select')).display === 'block'",
+            "() => window.getComputedStyle("
+            "document.getElementById('log-level-select')"
+            ").display === 'block'",
             timeout=TEST_TIMEOUT,
         )
 
@@ -161,7 +166,9 @@ def test_reset_flow(page: Page) -> None:
         page.evaluate("window.audioPressed([])")
 
         page.wait_for_function(
-            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'block'",
+            "() => window.getComputedStyle("
+            "document.getElementById('master-slider')"
+            ").display === 'block'",
             timeout=TEST_TIMEOUT,
         )
         wait_for_console_log(
@@ -316,10 +323,19 @@ def test_reset_flow(page: Page) -> None:
         ), "Reset log not found"
 
         # RESET-04: Reset persists after Back navigation
+        pre_sfx_count = len(logs)
         page.wait_for_function(
             "() => typeof window.changeSfxVolume !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.changeSfxVolume([0.2])")
+        wait_for_console_log(
+            lambda text: "applied loaded sfx volume to audioserver: 0.2" in text,
+            start_idx=pre_sfx_count,
+        )
+        page.wait_for_function(
+            "() => parseFloat(document.getElementById('sfx-slider').value) === 0.2",
+            timeout=TEST_TIMEOUT,
+        )
 
         pre_change_log_count = len(logs)
         page.wait_for_function(
@@ -330,6 +346,10 @@ def test_reset_flow(page: Page) -> None:
         wait_for_console_log(
             lambda text: "audio volumes reset to defaults" in text,
             start_idx=pre_change_log_count,
+        )
+        page.wait_for_function(
+            "() => parseFloat(document.getElementById('sfx-slider').value) === 1.0",
+            timeout=TEST_TIMEOUT,
         )
 
         page.wait_for_function(
@@ -343,7 +363,9 @@ def test_reset_flow(page: Page) -> None:
         page.evaluate("window.audioPressed([0])")
 
         page.wait_for_function(
-            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'block'",
+            "() => window.getComputedStyle("
+            "document.getElementById('master-slider')"
+            ").display === 'block'",
             timeout=TEST_TIMEOUT,
         )
         assert (
@@ -396,6 +418,10 @@ def test_reset_flow(page: Page) -> None:
             lambda text: "audio volumes reset to defaults" in text,
             start_idx=pre_change_log_count,
         )
+        page.wait_for_function(
+            "() => parseFloat(document.getElementById('sfx-slider').value) === 1.0",
+            timeout=TEST_TIMEOUT,
+        )
 
         # Reload and validate persisted defaults for all audio controls
         page.reload(wait_until="networkidle")
@@ -414,7 +440,9 @@ def test_reset_flow(page: Page) -> None:
         page.evaluate("window.audioPressed([])")
 
         page.wait_for_function(
-            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'block'",
+            "() => window.getComputedStyle("
+            "document.getElementById('master-slider')"
+            ").display === 'block'",
             timeout=TEST_TIMEOUT,
         )
 
@@ -451,7 +479,9 @@ def test_reset_flow(page: Page) -> None:
         )
         page.evaluate("window.audioBackPressed([])")
         page.wait_for_function(
-            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'none'",
+            "() => window.getComputedStyle("
+            "document.getElementById('master-slider')"
+            ").display === 'none'",
             timeout=TEST_TIMEOUT,
         )
 
@@ -467,7 +497,9 @@ def test_reset_flow(page: Page) -> None:
         )
         page.evaluate("window.audioPressed([])")
         page.wait_for_function(
-            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'block'",
+            "() => window.getComputedStyle("
+            "document.getElementById('master-slider')"
+            ").display === 'block'",
             timeout=TEST_TIMEOUT,
         )
 
@@ -486,7 +518,9 @@ def test_reset_flow(page: Page) -> None:
         )
         page.evaluate("window.audioBackPressed([])")
         page.wait_for_function(
-            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'none'",
+            "() => window.getComputedStyle("
+            "document.getElementById('master-slider')"
+            ").display === 'none'",
             timeout=TEST_TIMEOUT,
         )
 

--- a/tests/reset_audio_flow_test.py
+++ b/tests/reset_audio_flow_test.py
@@ -36,27 +36,7 @@ import pytest
 from playwright.sync_api import Page, expect
 
 # Configuration for stability in different environments
-DEFAULT_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "30000"))
-TEST_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "5000"))
-
-
-def wait_for_console_log(
-    logs: list[dict[str, str]],
-    predicate: Callable[[str], bool],
-    start_idx: int,
-    page: Page,
-    timeout_ms: int = TEST_TIMEOUT,
-) -> None:
-    """Helper to poll until a matching console log arrives or timeout expires."""
-    start_time = time.time()
-    while (time.time() - start_time) * 1000 < timeout_ms:
-        if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
-            return
-        page.wait_for_timeout(50)  # Micro-poll for event loop progression
-    pytest.fail(
-        "Timed out waiting for expected console log matching "
-        f"predicate after {timeout_ms}ms"
-    )
+from tests.test_utils import DEFAULT_TIMEOUT, TEST_TIMEOUT, wait_for_console_log
 
 
 def _has_log(logs: list[dict[str, str]], keyword: str) -> bool:

--- a/tests/reset_audio_flow_test.py
+++ b/tests/reset_audio_flow_test.py
@@ -32,7 +32,6 @@ import os
 import time
 from typing import Any, Callable
 
-import pytest
 from playwright.sync_api import Page, expect
 
 # Configuration for stability in different environments

--- a/tests/reset_audio_flow_test.py
+++ b/tests/reset_audio_flow_test.py
@@ -432,6 +432,12 @@ def test_reset_flow(page: Page) -> None:
             pre_change_log_count,
             page,
         )
+        wait_for_console_log(
+            logs,
+            lambda text: "saved" in text or "encrypted" in text or "falling back to plaintext" in text,
+            pre_change_log_count,
+            page,
+        )
         page.wait_for_function(
             "() => parseFloat("
             "document.getElementById('sfx-slider').value"

--- a/tests/reset_audio_flow_test.py
+++ b/tests/reset_audio_flow_test.py
@@ -434,7 +434,9 @@ def test_reset_flow(page: Page) -> None:
         )
         wait_for_console_log(
             logs,
-            lambda text: "saved" in text or "encrypted" in text or "falling back to plaintext" in text,
+            lambda text: "saved" in text
+            or "encrypted" in text
+            or "falling back to plaintext" in text,
             pre_change_log_count,
             page,
         )

--- a/tests/reset_audio_flow_test.py
+++ b/tests/reset_audio_flow_test.py
@@ -374,7 +374,8 @@ def test_reset_flow(page: Page) -> None:
             "() => typeof window.audioPressed !== 'undefined'",
             timeout=TEST_TIMEOUT,
         )
-        page.evaluate("window.audioPressed([0])")
+        # Update [0] to []
+        page.evaluate("window.audioPressed([])")
 
         page.wait_for_function(
             "() => window.getComputedStyle("

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,6 +15,16 @@ DEFAULT_TIMEOUT = int(os.getenv("DEFAULT_TIMEOUT", "30000"))
 TEST_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "5000"))
 
 
+def has_save_log(logs: list[dict[str, str]]) -> bool:
+    """Check if any log entry indicates settings were saved."""
+    return any(
+        ("encrypted" in log["text"].lower() and "settings" in log["text"].lower())
+        or "falling back to plaintext" in log["text"].lower()
+        or "saved" in log["text"].lower()
+        for log in logs
+    )
+
+
 def wait_for_console_log(
     logs: list[dict[str, str]],
     predicate: Callable[[str], bool],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,6 @@ import os
 import time
 from typing import Callable
 
-import pytest
 from playwright.sync_api import Page
 
 # Shared timeout configurations across test suites
@@ -38,7 +37,7 @@ def wait_for_console_log(
         if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
             return
         page.wait_for_timeout(50)  # Micro-poll for event loop progression
-    pytest.fail(
+    raise AssertionError(
         "Timed out waiting for expected console log matching "
         f"predicate after {timeout_ms}ms"
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,7 @@
 # Copyright (C) 2025 Egor Kostan
 # SPDX-License-Identifier: GPL-3.0-or-later
 # tests/test_utils.py
-"""
-Shared utility functions and helpers for SkyLockAssault Playwright E2E tests.
-"""
+"""Shared utility functions and helpers for SkyLockAssault Playwright E2E tests."""
 
 import os
 import time

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2025 Egor Kostan
+# SPDX-License-Identifier: GPL-3.0-or-later
+# tests/test_utils.py
+"""
+Shared utility functions and helpers for SkyLockAssault Playwright E2E tests.
+"""
+
+import os
+import time
+from typing import Callable
+
+import pytest
+from playwright.sync_api import Page
+
+# Shared timeout configurations across test suites
+DEFAULT_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "30000"))
+TEST_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "5000"))
+
+
+def wait_for_console_log(
+    logs: list[dict[str, str]],
+    predicate: Callable[[str], bool],
+    start_idx: int,
+    page: Page,
+    timeout_ms: int = TEST_TIMEOUT,
+) -> None:
+    """Helper to poll until a matching console log arrives or timeout expires."""
+    start_time = time.time()
+    while (time.time() - start_time) * 1000 < timeout_ms:
+        if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
+            return
+        page.wait_for_timeout(50)  # Micro-poll for event loop progression
+    pytest.fail(
+        "Timed out waiting for expected console log matching "
+        f"predicate after {timeout_ms}ms"
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,7 +13,7 @@ import pytest
 from playwright.sync_api import Page
 
 # Shared timeout configurations across test suites
-DEFAULT_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "30000"))
+DEFAULT_TIMEOUT = int(os.getenv("DEFAULT_TIMEOUT", "30000"))
 TEST_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "5000"))
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,8 +23,8 @@ def wait_for_console_log(
     timeout_ms: int = TEST_TIMEOUT,
 ) -> None:
     """Helper to poll until a matching console log arrives or timeout expires."""
-    start_time = time.time()
-    while (time.time() - start_time) * 1000 < timeout_ms:
+    start_time = time.monotonic()
+    while (time.monotonic() - start_time) * 1000 < timeout_ms:
         if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
             return
         page.wait_for_timeout(50)  # Micro-poll for event loop progression

--- a/tests/validate_clean_load_test.py
+++ b/tests/validate_clean_load_test.py
@@ -54,7 +54,9 @@ def test_no_critical_errors_on_load(page: Page) -> None:
         )
 
         # 2. Wait deterministically for the engine's ready signal and canvas visibility
-        page.wait_for_function("() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT)
+        page.wait_for_function(
+            "() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT
+        )
         expect(page.locator("canvas")).to_be_visible(timeout=DEFAULT_TIMEOUT)
 
         # 3. Analyze captured logs for the specific patterns

--- a/tests/validate_clean_load_test.py
+++ b/tests/validate_clean_load_test.py
@@ -21,7 +21,7 @@ Test Flow
 import os
 import time
 
-from playwright.sync_api import Page
+from playwright.sync_api import Page, expect
 
 # Configuration for stability in different environments
 # Default to 5000ms, but allow CI to override via environment variable
@@ -52,11 +52,10 @@ def test_no_critical_errors_on_load(page: Page) -> None:
             wait_until="networkidle",
             timeout=DEFAULT_TIMEOUT,
         )
-        # 1.5. Wait for the engine to actually start the splash scene
-        page.wait_for_timeout(TEST_TIMEOUT)
 
-        # 2. Wait for the engine's ready signal
-        page.wait_for_function("() => window.godotInitialized", timeout=DEFAULT_TIMEOUT)
+        # 2. Wait deterministically for the engine's ready signal and canvas visibility
+        page.wait_for_function("() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT)
+        expect(page.locator("canvas")).to_be_visible(timeout=DEFAULT_TIMEOUT)
 
         # 3. Analyze captured logs for the specific patterns
         # We only check for patterns within 'error' or 'warning' logs to avoid false positives

--- a/tests/validate_clean_load_test.py
+++ b/tests/validate_clean_load_test.py
@@ -25,8 +25,7 @@ from playwright.sync_api import Page, expect
 
 # Configuration for stability in different environments
 # Default to 5000ms, but allow CI to override via environment variable
-DEFAULT_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "30000"))
-TEST_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "5000"))
+from tests.test_utils import DEFAULT_TIMEOUT
 
 
 def test_no_critical_errors_on_load(page: Page) -> None:

--- a/tests/volume_sliders_mutes_test.py
+++ b/tests/volume_sliders_mutes_test.py
@@ -64,18 +64,19 @@ def test_volume_sliders_mutes(page: Page) -> None:
     page.on("console", on_console)
 
     def wait_for_console_log(
-        predicate: Callable[[str], bool], start_idx: int, timeout_ms: int = TEST_TIMEOUT
+        predicate: Callable[[str], bool],
+        start_idx: int,
+        timeout_ms: int = TEST_TIMEOUT,
     ) -> None:
-        """
-        Helper to poll until a matching console log arrives or timeout expires.
-        """
+        """Helper to poll until a matching console log arrives or timeout expires."""
         start_time = time.time()
         while (time.time() - start_time) * 1000 < timeout_ms:
             if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
                 return
             page.wait_for_timeout(50)  # Micro-poll for event loop progression
         pytest.fail(
-            f"Timed out waiting for expected console log matching predicate after {timeout_ms}ms"
+            "Timed out waiting for expected console log matching "
+            f"predicate after {timeout_ms}ms"
         )
 
     try:
@@ -123,7 +124,9 @@ def test_volume_sliders_mutes(page: Page) -> None:
             "() => typeof window.changeLogLevel !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.wait_for_function(
-            "() => window.getComputedStyle(document.getElementById('log-level-select')).display === 'block'",
+            "() => window.getComputedStyle("
+            "document.getElementById('log-level-select')"
+            ").display === 'block'",
             timeout=TEST_TIMEOUT,
         )
 
@@ -156,7 +159,9 @@ def test_volume_sliders_mutes(page: Page) -> None:
         page.evaluate("window.audioPressed([])")
 
         page.wait_for_function(
-            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'block'",
+            "() => window.getComputedStyle("
+            "document.getElementById('master-slider')"
+            ").display === 'block'",
             timeout=TEST_TIMEOUT,
         )
         wait_for_console_log(

--- a/tests/volume_sliders_mutes_test.py
+++ b/tests/volume_sliders_mutes_test.py
@@ -28,11 +28,12 @@ v8_coverage_volume_sliders_mutes_test.json, artifacts/test_volume_failure_*.png/
 import json
 import os
 import time
+from typing import Any, Callable
 
-from playwright.sync_api import Page
+import pytest
+from playwright.sync_api import Page, expect
 
 # Configuration for stability in different environments
-# Default to 5000ms, but allow CI to override via environment variable
 DEFAULT_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "30000"))
 TEST_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "5000"))
 
@@ -50,7 +51,7 @@ def test_volume_sliders_mutes(page: Page) -> None:
     logs: list[dict[str, str]] = []
     cdp_session = None
 
-    def on_console(msg) -> None:
+    def on_console(msg: Any) -> None:
         """
         Console message handler to capture logs.
 
@@ -61,8 +62,22 @@ def test_volume_sliders_mutes(page: Page) -> None:
         logs.append({"type": msg.type, "text": msg.text})
 
     page.on("console", on_console)
+
+    def wait_for_console_log(
+            predicate: Callable[[str], bool], start_idx: int, timeout_ms: int = TEST_TIMEOUT
+    ) -> None:
+        """
+        Helper to poll until a matching console log arrives or timeout expires.
+        """
+        start_time = time.time()
+        while (time.time() - start_time) * 1000 < timeout_ms:
+            if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
+                return
+            page.wait_for_timeout(50)  # Micro-poll for event loop progression
+        pytest.fail(f"Timed out waiting for expected console log matching predicate after {timeout_ms}ms")
+
     try:
-        # Start CDP session for V8 JS coverage (workaround for Python Playwright lacking native coverage API)
+        # Start CDP session for V8 JS coverage
         cdp_session = page.context.new_cdp_session(page)
         cdp_session.send("Profiler.enable")
         cdp_session.send(
@@ -74,22 +89,21 @@ def test_volume_sliders_mutes(page: Page) -> None:
             wait_until="networkidle",
             timeout=DEFAULT_TIMEOUT,
         )
-        # 1. Wait for the engine to actually start the splash scene
-        page.wait_for_timeout(TEST_TIMEOUT)
-        page.wait_for_function("() => window.godotInitialized", timeout=DEFAULT_TIMEOUT)
+
+        # 1. Wait deterministically for Godot engine initialization
+        page.wait_for_function("() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT)
 
         # Verify canvas
         canvas = page.locator("canvas")
-        page.wait_for_selector("canvas", state="visible", timeout=DEFAULT_TIMEOUT)
+        expect(canvas).to_be_visible(timeout=DEFAULT_TIMEOUT)
         box: dict[str, float] | None = canvas.bounding_box()
         assert box is not None, "Canvas not found"
         assert "SkyLockAssault" in page.title(), "Title not found"
 
         # Open options
         page.wait_for_selector("#options-button", state="visible", timeout=TEST_TIMEOUT)
-        # page.click("#options-button", force=True)
         page.wait_for_function(
-            "window.optionsPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.optionsPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.optionsPressed([])")
 
@@ -97,28 +111,24 @@ def test_volume_sliders_mutes(page: Page) -> None:
         page.wait_for_selector(
             "#advanced-button", state="visible", timeout=TEST_TIMEOUT
         )
-        # page.click("#advanced-button", force=True)
         page.wait_for_function(
-            "window.advancedPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.advancedPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.advancedPressed([])")
         page.wait_for_function(
-            "window.changeLogLevel !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.changeLogLevel !== 'undefined'", timeout=TEST_TIMEOUT
         )
-        advanced_display: str = page.evaluate(
-            "window.getComputedStyle(document.getElementById('log-level-select')).display"
+        page.wait_for_function(
+            "() => window.getComputedStyle(document.getElementById('log-level-select')).display === 'block'",
+            timeout=TEST_TIMEOUT,
         )
-        assert (
-            advanced_display == "block"
-        ), "Advanced menu not loaded (selected log level not displayed)"
 
         # Set log level DEBUG
         pre_change_log_count = len(logs)
         page.evaluate("window.changeLogLevel([0])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        new_logs = logs[pre_change_log_count:]
-        assert any(
-            "log level changed to: debug" in log["text"].lower() for log in new_logs
+        wait_for_console_log(
+            lambda text: "log level changed to: debug" in text,
+            start_idx=pre_change_log_count,
         )
         assert page.evaluate(
             "document.getElementById('audio-button') !== null"
@@ -128,47 +138,37 @@ def test_volume_sliders_mutes(page: Page) -> None:
         page.wait_for_selector(
             "#advanced-back-button", state="visible", timeout=TEST_TIMEOUT
         )
-        # page.click("#advanced-back-button", force=True)
         page.wait_for_function(
-            "window.advancedBackPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.advancedBackPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.advancedBackPressed([])")
 
-        # Navigate to audio sub-menu (use coordinates for Godot-rendered button)
-        canvas = page.locator("canvas")
-        box: dict[str, float] | None = canvas.bounding_box()
-        assert box is not None, "Canvas not found"
         # Open audio
         pre_change_log_count = len(logs)
-        # page.click("#audio-button", force=True)
         page.wait_for_function(
-            "window.audioPressed !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.audioPressed !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.audioPressed([])")
-        page.wait_for_timeout(TEST_TIMEOUT)  # Wait for audio scene load
-        audio_display: str = page.evaluate(
-            "window.getComputedStyle(document.getElementById('master-slider')).display"
+
+        page.wait_for_function(
+            "() => window.getComputedStyle(document.getElementById('master-slider')).display === 'block'",
+            timeout=TEST_TIMEOUT,
         )
-        assert (
-            audio_display == "block"
-        ), "Audio menu not loaded (master-slider not displayed)"
-        new_logs = logs[pre_change_log_count:]
-        assert any(
-            "audio button pressed" in log["text"].lower() for log in new_logs
-        ), "Audio navigation log not found"
+        wait_for_console_log(
+            lambda text: "audio button pressed" in text,
+            start_idx=pre_change_log_count,
+        )
 
         # VOL-01: Adjust Master volume slider
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "window.changeMasterVolume !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.changeMasterVolume !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.changeMasterVolume([0.5])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        new_logs = logs[pre_change_log_count:]
-        assert any(
-            "applied loaded master volume to audioserver: 0.5" in log["text"].lower()
-            for log in new_logs
-        ), "Master volume change log not found"
+        wait_for_console_log(
+            lambda text: "applied loaded master volume to audioserver: 0.5" in text,
+            start_idx=pre_change_log_count,
+        )
         value = page.evaluate("document.getElementById('master-slider').value")
         assert value == "0.5", f"Master slider value not set to 0.5, got {value}"
 
@@ -176,279 +176,222 @@ def test_volume_sliders_mutes(page: Page) -> None:
         # MUTE
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "window.toggleMuteMaster !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteMaster !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.toggleMuteMaster([0])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        new_logs = logs[pre_change_log_count:]
-        assert any(
-            "master is muted" in log["text"].lower() for log in new_logs
-        ), "Master mute log not found"
+        wait_for_console_log(
+            lambda text: "master is muted" in text,
+            start_idx=pre_change_log_count,
+        )
         checked = page.evaluate("document.getElementById('mute-master').checked")
         assert not checked, "Master mute not toggled to muted"
+
         # UNMUTE
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "window.toggleMuteMaster !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteMaster !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.toggleMuteMaster([1])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        new_logs = logs[pre_change_log_count:]
-        assert any(
-            "applied loaded master volume to audioserver: 0.5" in log["text"].lower()
-            for log in new_logs
-        ), "Master mute log not found"
+        wait_for_console_log(
+            lambda text: "master mute button toggled to: true" in text,
+            start_idx=pre_change_log_count,
+        )
         checked = page.evaluate("document.getElementById('mute-master').checked")
         assert checked, "Master mute not toggled to unmuted"
-        assert any(
-            "master mute button toggled to: true" in log["text"].lower()
-            for log in new_logs
-        ), "Master unmute log not found"
 
         # VOL-03: Adjust Music volume slider
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "window.changeMusicVolume !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.changeMusicVolume !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.changeMusicVolume([0.3])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        new_logs = logs[pre_change_log_count:]
+        wait_for_console_log(
+            lambda text: "applied loaded music volume to audioserver: 0.3" in text,
+            start_idx=pre_change_log_count,
+        )
         value = page.evaluate("document.getElementById('music-slider').value")
         assert value == "0.3", f"Music slider value not set to 0.3, got {value}"
-        assert any(
-            "applied loaded music volume to audioserver: 0.3" in log["text"].lower()
-            for log in new_logs
-        ), "Music volume change log not found"
 
         # VOL-04: Mute / unmute Music
         # MUTE
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "window.toggleMuteMusic !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteMusic !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.toggleMuteMusic([0])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        new_logs = logs[pre_change_log_count:]
-        assert any(
-            "music is muted" in log["text"].lower() for log in new_logs
-        ), "Music mute log not found"
+        wait_for_console_log(
+            lambda text: "music is muted" in text,
+            start_idx=pre_change_log_count,
+        )
         checked = page.evaluate("document.getElementById('mute-music').checked")
         assert not checked, "Music mute not toggled to muted"
+
         # UNMUTE
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "window.toggleMuteMusic !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteMusic !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.toggleMuteMusic([1])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        new_logs = logs[pre_change_log_count:]
-        assert any(
-            "applied loaded music volume to audioserver: 0.3" in log["text"].lower()
-            for log in new_logs
-        ), "Music unmute log not found"
+        wait_for_console_log(
+            lambda text: "music mute button toggled to: true" in text,
+            start_idx=pre_change_log_count,
+        )
         checked = page.evaluate("document.getElementById('mute-music').checked")
         assert checked, "Music mute not toggled to unmuted"
-        assert any(
-            "music mute button toggled to: true" in log["text"].lower()
-            for log in new_logs
-        ), "Music unmute log not found"
 
         # VOL-05: Adjust SFX volume slider
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "window.changeSfxVolume !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.changeSfxVolume !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.changeSfxVolume([0.8])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        new_logs = logs[pre_change_log_count:]
+        wait_for_console_log(
+            lambda text: "applied loaded sfx volume to audioserver: 0.8" in text,
+            start_idx=pre_change_log_count,
+        )
         value = page.evaluate("document.getElementById('sfx-slider').value")
         assert value == "0.8", f"SFX slider value not set to 0.8, got {value}"
-        assert any(
-            "applied loaded sfx volume to audioserver: 0.8" in log["text"].lower()
-            for log in new_logs
-        ), "SFX volume change log not found"
-        assert any(
-            "sfx volume level in audiomanager: 0.8" in log["text"].lower()
-            for log in new_logs
-        ), "SFX volume change log not found"
-        assert any(
-            "saved volumes to config" in log["text"].lower() for log in new_logs
-        ), "SFX volume change log not found"
 
         # VOL-06: Mute / unmute SFX
         # MUTE
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "window.toggleMuteSfx !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteSfx !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.toggleMuteSfx([0])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        new_logs = logs[pre_change_log_count:]
-        assert any(
-            "sfx is muted" in log["text"].lower() for log in new_logs
-        ), "SFX mute log not found"
+        wait_for_console_log(
+            lambda text: "sfx is muted" in text,
+            start_idx=pre_change_log_count,
+        )
         checked = page.evaluate("document.getElementById('mute-sfx').checked")
         assert not checked, "SFX mute not toggled to muted"
+
         # UNMUTE
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "window.toggleMuteSfx !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteSfx !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.toggleMuteSfx([1])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        new_logs = logs[pre_change_log_count:]
-        assert any(
-            "applied loaded sfx volume to audioserver: 0.8" in log["text"].lower()
-            for log in new_logs
-        ), "SFX unmute log not found"
+        wait_for_console_log(
+            lambda text: "sfx mute button toggled to: true" in text,
+            start_idx=pre_change_log_count,
+        )
         checked = page.evaluate("document.getElementById('mute-sfx').checked")
         assert checked, "SFX mute not toggled to unmuted"
-        assert any(
-            "sfx mute button toggled to: true" in log["text"].lower()
-            for log in new_logs
-        ), "SFX unmute log not found"
 
         # VOL-07: Adjust Weapon volume slider
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "window.changeWeaponVolume !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.changeWeaponVolume !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.changeWeaponVolume([0.2])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        new_logs = logs[pre_change_log_count:]
+        wait_for_console_log(
+            lambda text: "applied loaded sfx_weapon volume to audioserver: 0.2" in text,
+            start_idx=pre_change_log_count,
+        )
         value = page.evaluate("document.getElementById('weapon-slider').value")
         assert value == "0.2", f"Weapon slider value not set to 0.2, got {value}"
-        assert any(
-            "applied loaded sfx_weapon volume to audioserver: 0.2"
-            in log["text"].lower()
-            for log in new_logs
-        ), "Weapon volume change log not found"
 
         # VOL-08: Mute / unmute Weapon
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "window.toggleMuteWeapon !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteWeapon !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.toggleMuteWeapon([0])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        new_logs = logs[pre_change_log_count:]
-        assert any(
-            "weapon is muted" in log["text"].lower() for log in new_logs
-        ), "Weapon mute log not found"
+        wait_for_console_log(
+            lambda text: "weapon is muted" in text,
+            start_idx=pre_change_log_count,
+        )
         checked = page.evaluate("document.getElementById('mute-weapon').checked")
         assert not checked, "Weapon mute not toggled to muted"
+
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "window.toggleMuteWeapon !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteWeapon !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.toggleMuteWeapon([1])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        new_logs = logs[pre_change_log_count:]
-        assert any(
-            "applied loaded sfx_weapon volume to audioserver: 0.2"
-            in log["text"].lower()
-            for log in new_logs
-        ), "Weapon unmute log not found"
+        wait_for_console_log(
+            lambda text: "weapon mute button toggled to: true" in text,
+            start_idx=pre_change_log_count,
+        )
         checked = page.evaluate("document.getElementById('mute-weapon').checked")
         assert checked, "Weapon mute not toggled to unmuted"
-        assert any(
-            "weapon mute button toggled to: true" in log["text"].lower()
-            for log in new_logs
-        ), "Weapon unmute log not found"
 
         # VOL-09: Adjust Rotors volume slider
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "window.changeRotorsVolume !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.changeRotorsVolume !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.changeRotorsVolume([0.9])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        new_logs = logs[pre_change_log_count:]
+        wait_for_console_log(
+            lambda text: "applied loaded sfx_rotors volume to audioserver: 0.9" in text,
+            start_idx=pre_change_log_count,
+        )
         value = page.evaluate("document.getElementById('rotors-slider').value")
         assert value == "0.9", f"Rotors slider value not set to 0.9, got {value}"
-        assert any(
-            "applied loaded sfx_rotors volume to audioserver: 0.9"
-            in log["text"].lower()
-            for log in new_logs
-        ), "Rotors volume change log not found"
 
         # VOL-10: Mute / unmute Rotors
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "window.toggleMuteRotors !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteRotors !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.toggleMuteRotors([0])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        new_logs = logs[pre_change_log_count:]
-        assert any(
-            "rotors is muted" in log["text"].lower() for log in new_logs
-        ), "Rotors mute log not found"
+        wait_for_console_log(
+            lambda text: "rotors is muted" in text,
+            start_idx=pre_change_log_count,
+        )
         checked = page.evaluate("document.getElementById('mute-rotors').checked")
         assert not checked, "Rotors mute not toggled to muted"
+
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "window.toggleMuteRotors !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteRotors !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.toggleMuteRotors([1])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        new_logs = logs[pre_change_log_count:]
-        assert any(
-            "applied loaded sfx_rotors volume to audioserver: 0.9"
-            in log["text"].lower()
-            for log in new_logs
-        ), "Rotors unmute log not found"
+        wait_for_console_log(
+            lambda text: "rotors mute button toggled to: true" in text,
+            start_idx=pre_change_log_count,
+        )
         checked = page.evaluate("document.getElementById('mute-rotors').checked")
         assert checked, "Rotors mute not toggled to unmuted"
-        assert any(
-            "rotors mute button toggled to: true" in log["text"].lower()
-            for log in new_logs
-        ), "Rotors unmute log not found"
 
         # VOL-11: Adjust Menu volume slider
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "window.changeMenuVolume !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.changeMenuVolume !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.changeMenuVolume([0.9])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        new_logs = logs[pre_change_log_count:]
+        wait_for_console_log(
+            lambda text: "applied loaded sfx_menu volume to audioserver: 0.9" in text,
+            start_idx=pre_change_log_count,
+        )
         value = page.evaluate("document.getElementById('menu-slider').value")
         assert value == "0.9", f"Menu slider value not set to 0.9, got {value}"
-        assert any(
-            "applied loaded sfx_menu volume to audioserver: 0.9" in log["text"].lower()
-            for log in new_logs
-        ), "Menu volume change log not found"
 
         # VOL-12: Mute / unmute Menu
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "window.toggleMuteMenu !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteMenu !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.toggleMuteMenu([0])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        new_logs = logs[pre_change_log_count:]
-        assert any(
-            "menu is muted" in log["text"].lower() for log in new_logs
-        ), "Menu mute log not found"
+        wait_for_console_log(
+            lambda text: "menu is muted" in text,
+            start_idx=pre_change_log_count,
+        )
         checked = page.evaluate("document.getElementById('mute-menu').checked")
         assert not checked, "Menu mute not toggled to muted"
+
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "window.toggleMuteMenu !== undefined", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteMenu !== 'undefined'", timeout=TEST_TIMEOUT
         )
         page.evaluate("window.toggleMuteMenu([1])")
-        page.wait_for_timeout(TEST_TIMEOUT)
-        new_logs = logs[pre_change_log_count:]
-        assert any(
-            "applied loaded sfx_menu volume to audioserver: 0.9" in log["text"].lower()
-            for log in new_logs
-        ), "Menu unmute log not found"
+        wait_for_console_log(
+            lambda text: "menu mute button toggled to: true" in text,
+            start_idx=pre_change_log_count,
+        )
         checked = page.evaluate("document.getElementById('mute-menu').checked")
         assert checked, "Menu mute not toggled to unmuted"
-        assert any(
-            "menu mute button toggled to: true" in log["text"].lower()
-            for log in new_logs
-        ), "Menu unmute log not found"
 
     except Exception as e:
         print(f"Test suite failed: {str(e)}")
@@ -458,14 +401,13 @@ def test_volume_sliders_mutes(page: Page) -> None:
             path=f"artifacts/test_volume_failure_screenshot_{timestamp}.png"
         )
         with open(
-            f"artifacts/test_volume_failure_console_logs_{timestamp}.txt", "w"
+                f"artifacts/test_volume_failure_console_logs_{timestamp}.txt", "w"
         ) as f:
             for log in logs:
                 f.write(f"[{log['type']}] {log['text']}\n")
         raise
     finally:
         if cdp_session:
-            # Stop V8 coverage and save to file (even on failure)
             coverage = cdp_session.send("Profiler.takePreciseCoverage")["result"]
             cdp_session.send("Profiler.stopPreciseCoverage")
             cdp_session.send("Profiler.disable")

--- a/tests/volume_sliders_mutes_test.py
+++ b/tests/volume_sliders_mutes_test.py
@@ -64,7 +64,7 @@ def test_volume_sliders_mutes(page: Page) -> None:
     page.on("console", on_console)
 
     def wait_for_console_log(
-            predicate: Callable[[str], bool], start_idx: int, timeout_ms: int = TEST_TIMEOUT
+        predicate: Callable[[str], bool], start_idx: int, timeout_ms: int = TEST_TIMEOUT
     ) -> None:
         """
         Helper to poll until a matching console log arrives or timeout expires.
@@ -74,7 +74,9 @@ def test_volume_sliders_mutes(page: Page) -> None:
             if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
                 return
             page.wait_for_timeout(50)  # Micro-poll for event loop progression
-        pytest.fail(f"Timed out waiting for expected console log matching predicate after {timeout_ms}ms")
+        pytest.fail(
+            f"Timed out waiting for expected console log matching predicate after {timeout_ms}ms"
+        )
 
     try:
         # Start CDP session for V8 JS coverage
@@ -91,7 +93,9 @@ def test_volume_sliders_mutes(page: Page) -> None:
         )
 
         # 1. Wait deterministically for Godot engine initialization
-        page.wait_for_function("() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT)
+        page.wait_for_function(
+            "() => window.godotInitialized === true", timeout=DEFAULT_TIMEOUT
+        )
 
         # Verify canvas
         canvas = page.locator("canvas")
@@ -139,7 +143,8 @@ def test_volume_sliders_mutes(page: Page) -> None:
             "#advanced-back-button", state="visible", timeout=TEST_TIMEOUT
         )
         page.wait_for_function(
-            "() => typeof window.advancedBackPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.advancedBackPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.advancedBackPressed([])")
 
@@ -162,7 +167,8 @@ def test_volume_sliders_mutes(page: Page) -> None:
         # VOL-01: Adjust Master volume slider
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.changeMasterVolume !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.changeMasterVolume !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.changeMasterVolume([0.5])")
         wait_for_console_log(
@@ -202,7 +208,8 @@ def test_volume_sliders_mutes(page: Page) -> None:
         # VOL-03: Adjust Music volume slider
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.changeMusicVolume !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.changeMusicVolume !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.changeMusicVolume([0.3])")
         wait_for_console_log(
@@ -282,7 +289,8 @@ def test_volume_sliders_mutes(page: Page) -> None:
         # VOL-07: Adjust Weapon volume slider
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.changeWeaponVolume !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.changeWeaponVolume !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.changeWeaponVolume([0.2])")
         wait_for_console_log(
@@ -320,7 +328,8 @@ def test_volume_sliders_mutes(page: Page) -> None:
         # VOL-09: Adjust Rotors volume slider
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.changeRotorsVolume !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.changeRotorsVolume !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.changeRotorsVolume([0.9])")
         wait_for_console_log(
@@ -401,7 +410,7 @@ def test_volume_sliders_mutes(page: Page) -> None:
             path=f"artifacts/test_volume_failure_screenshot_{timestamp}.png"
         )
         with open(
-                f"artifacts/test_volume_failure_console_logs_{timestamp}.txt", "w"
+            f"artifacts/test_volume_failure_console_logs_{timestamp}.txt", "w"
         ) as f:
             for log in logs:
                 f.write(f"[{log['type']}] {log['text']}\n")

--- a/tests/volume_sliders_mutes_test.py
+++ b/tests/volume_sliders_mutes_test.py
@@ -118,9 +118,7 @@ def test_volume_sliders_mutes(page: Page) -> None:
         assert "SkyLockAssault" in page.title(), "Title not found"
 
         # Open options
-        page.wait_for_selector(
-            "#options-button", state="visible", timeout=TEST_TIMEOUT
-        )
+        page.wait_for_selector("#options-button", state="visible", timeout=TEST_TIMEOUT)
         page.wait_for_function(
             "() => typeof window.optionsPressed !== 'undefined'",
             timeout=TEST_TIMEOUT,
@@ -370,8 +368,7 @@ def test_volume_sliders_mutes(page: Page) -> None:
         page.evaluate("window.changeWeaponVolume([0.2])")
         wait_for_console_log(
             logs,
-            lambda text: "applied loaded sfx_weapon volume to audioserver: 0.2"
-            in text,
+            lambda text: "applied loaded sfx_weapon volume to audioserver: 0.2" in text,
             pre_change_log_count,
             page,
         )
@@ -418,8 +415,7 @@ def test_volume_sliders_mutes(page: Page) -> None:
         page.evaluate("window.changeRotorsVolume([0.9])")
         wait_for_console_log(
             logs,
-            lambda text: "applied loaded sfx_rotors volume to audioserver: 0.9"
-            in text,
+            lambda text: "applied loaded sfx_rotors volume to audioserver: 0.9" in text,
             pre_change_log_count,
             page,
         )
@@ -466,8 +462,7 @@ def test_volume_sliders_mutes(page: Page) -> None:
         page.evaluate("window.changeMenuVolume([0.9])")
         wait_for_console_log(
             logs,
-            lambda text: "applied loaded sfx_menu volume to audioserver: 0.9"
-            in text,
+            lambda text: "applied loaded sfx_menu volume to audioserver: 0.9" in text,
             pre_change_log_count,
             page,
         )

--- a/tests/volume_sliders_mutes_test.py
+++ b/tests/volume_sliders_mutes_test.py
@@ -2,14 +2,13 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 # tests/volume_sliders_mutes_test.py
 """
-Volume Sliders & Mute Toggles Test Suite (Playwright + UI Automation with DOM Overlays)
-=====================================================================================
+Volume Sliders & Mute Toggles Test Suite (Playwright + UI Automation Overlay)
+=============================================================================
 
 Overview
 --------
-E2E tests for VOL-01 to VOL-10: Validate volume slider adjustments and mute toggles in audio menu.
-
-Assumes navigation to audio menu (reuses navigation logic). Verifies DOM value/checked states and console logs (DEBUG level).
+E2E tests for VOL-01 to VOL-12: Validate volume slider adjustments, side-effect
+logging (AudioManager + persistence), and mute toggles in the audio menu.
 
 Prerequisites
 -------------
@@ -38,11 +37,40 @@ DEFAULT_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "30000"))
 TEST_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "5000"))
 
 
+def wait_for_console_log(
+    logs: list[dict[str, str]],
+    predicate: Callable[[str], bool],
+    start_idx: int,
+    page: Page,
+    timeout_ms: int = TEST_TIMEOUT,
+) -> None:
+    """Helper to poll until a matching console log arrives or timeout expires."""
+    start_time = time.time()
+    while (time.time() - start_time) * 1000 < timeout_ms:
+        if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
+            return
+        page.wait_for_timeout(50)  # Micro-poll for event loop progression
+    pytest.fail(
+        "Timed out waiting for expected console log matching "
+        f"predicate after {timeout_ms}ms"
+    )
+
+
+def _has_save_log(logs: list[dict[str, str]]) -> bool:
+    """Check if any log entry indicates settings were saved."""
+    return any(
+        ("encrypted" in log["text"].lower() and "settings" in log["text"].lower())
+        or "falling back to plaintext" in log["text"].lower()
+        or "saved" in log["text"].lower()
+        for log in logs
+    )
+
+
 def test_volume_sliders_mutes(page: Page) -> None:
     """
     Main test suite for volume sliders and mute toggles using DOM overlays.
 
-    Implements VOL-01 to VOL-10: Adjust sliders, toggle mutes, verify states/logs.
+    Implements VOL-01 to VOL-12: Adjust sliders, toggle mutes, verify states/logs.
 
     :param page: The Playwright page object.
     :type page: Page
@@ -62,22 +90,6 @@ def test_volume_sliders_mutes(page: Page) -> None:
         logs.append({"type": msg.type, "text": msg.text})
 
     page.on("console", on_console)
-
-    def wait_for_console_log(
-        predicate: Callable[[str], bool],
-        start_idx: int,
-        timeout_ms: int = TEST_TIMEOUT,
-    ) -> None:
-        """Helper to poll until a matching console log arrives or timeout expires."""
-        start_time = time.time()
-        while (time.time() - start_time) * 1000 < timeout_ms:
-            if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
-                return
-            page.wait_for_timeout(50)  # Micro-poll for event loop progression
-        pytest.fail(
-            "Timed out waiting for expected console log matching "
-            f"predicate after {timeout_ms}ms"
-        )
 
     try:
         # Start CDP session for V8 JS coverage
@@ -106,9 +118,12 @@ def test_volume_sliders_mutes(page: Page) -> None:
         assert "SkyLockAssault" in page.title(), "Title not found"
 
         # Open options
-        page.wait_for_selector("#options-button", state="visible", timeout=TEST_TIMEOUT)
+        page.wait_for_selector(
+            "#options-button", state="visible", timeout=TEST_TIMEOUT
+        )
         page.wait_for_function(
-            "() => typeof window.optionsPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.optionsPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.optionsPressed([])")
 
@@ -117,11 +132,13 @@ def test_volume_sliders_mutes(page: Page) -> None:
             "#advanced-button", state="visible", timeout=TEST_TIMEOUT
         )
         page.wait_for_function(
-            "() => typeof window.advancedPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.advancedPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.advancedPressed([])")
         page.wait_for_function(
-            "() => typeof window.changeLogLevel !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.changeLogLevel !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.wait_for_function(
             "() => window.getComputedStyle("
@@ -134,8 +151,10 @@ def test_volume_sliders_mutes(page: Page) -> None:
         pre_change_log_count = len(logs)
         page.evaluate("window.changeLogLevel([0])")
         wait_for_console_log(
+            logs,
             lambda text: "log level changed to: debug" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
         assert page.evaluate(
             "document.getElementById('audio-button') !== null"
@@ -154,7 +173,8 @@ def test_volume_sliders_mutes(page: Page) -> None:
         # Open audio
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.audioPressed !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.audioPressed !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.audioPressed([])")
 
@@ -165,8 +185,10 @@ def test_volume_sliders_mutes(page: Page) -> None:
             timeout=TEST_TIMEOUT,
         )
         wait_for_console_log(
+            logs,
             lambda text: "audio button pressed" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
 
         # VOL-01: Adjust Master volume slider
@@ -177,35 +199,49 @@ def test_volume_sliders_mutes(page: Page) -> None:
         )
         page.evaluate("window.changeMasterVolume([0.5])")
         wait_for_console_log(
+            logs,
             lambda text: "applied loaded master volume to audioserver: 0.5" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
+        )
+        wait_for_console_log(
+            logs,
+            lambda text: "master volume level in audiomanager: 0.5" in text
+            or "saved" in text
+            or "encrypted" in text,
+            pre_change_log_count,
+            page,
         )
         value = page.evaluate("document.getElementById('master-slider').value")
         assert value == "0.5", f"Master slider value not set to 0.5, got {value}"
 
         # VOL-02: Mute / unmute Master
-        # MUTE
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.toggleMuteMaster !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteMaster !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.toggleMuteMaster([0])")
         wait_for_console_log(
+            logs,
             lambda text: "master is muted" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
         checked = page.evaluate("document.getElementById('mute-master').checked")
         assert not checked, "Master mute not toggled to muted"
 
-        # UNMUTE
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.toggleMuteMaster !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteMaster !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.toggleMuteMaster([1])")
         wait_for_console_log(
+            logs,
             lambda text: "master mute button toggled to: true" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
         checked = page.evaluate("document.getElementById('mute-master').checked")
         assert checked, "Master mute not toggled to unmuted"
@@ -218,35 +254,49 @@ def test_volume_sliders_mutes(page: Page) -> None:
         )
         page.evaluate("window.changeMusicVolume([0.3])")
         wait_for_console_log(
+            logs,
             lambda text: "applied loaded music volume to audioserver: 0.3" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
+        )
+        wait_for_console_log(
+            logs,
+            lambda text: "music volume level in audiomanager: 0.3" in text
+            or "saved" in text
+            or "encrypted" in text,
+            pre_change_log_count,
+            page,
         )
         value = page.evaluate("document.getElementById('music-slider').value")
         assert value == "0.3", f"Music slider value not set to 0.3, got {value}"
 
         # VOL-04: Mute / unmute Music
-        # MUTE
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.toggleMuteMusic !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteMusic !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.toggleMuteMusic([0])")
         wait_for_console_log(
+            logs,
             lambda text: "music is muted" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
         checked = page.evaluate("document.getElementById('mute-music').checked")
         assert not checked, "Music mute not toggled to muted"
 
-        # UNMUTE
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.toggleMuteMusic !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteMusic !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.toggleMuteMusic([1])")
         wait_for_console_log(
+            logs,
             lambda text: "music mute button toggled to: true" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
         checked = page.evaluate("document.getElementById('mute-music').checked")
         assert checked, "Music mute not toggled to unmuted"
@@ -254,39 +304,59 @@ def test_volume_sliders_mutes(page: Page) -> None:
         # VOL-05: Adjust SFX volume slider
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.changeSfxVolume !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.changeSfxVolume !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.changeSfxVolume([0.8])")
         wait_for_console_log(
+            logs,
             lambda text: "applied loaded sfx volume to audioserver: 0.8" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
+        wait_for_console_log(
+            logs,
+            lambda text: "sfx volume level in audiomanager: 0.8" in text
+            or "saved" in text
+            or "encrypted" in text,
+            pre_change_log_count,
+            page,
+        )
+        sfx_logs = logs[pre_change_log_count:]
+        assert any(
+            "sfx volume level in audiomanager: 0.8" in log["text"].lower()
+            for log in sfx_logs
+        ) or _has_save_log(sfx_logs), "SFX volume side effect log missing"
         value = page.evaluate("document.getElementById('sfx-slider').value")
         assert value == "0.8", f"SFX slider value not set to 0.8, got {value}"
 
         # VOL-06: Mute / unmute SFX
-        # MUTE
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.toggleMuteSfx !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteSfx !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.toggleMuteSfx([0])")
         wait_for_console_log(
+            logs,
             lambda text: "sfx is muted" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
         checked = page.evaluate("document.getElementById('mute-sfx').checked")
         assert not checked, "SFX mute not toggled to muted"
 
-        # UNMUTE
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.toggleMuteSfx !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteSfx !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.toggleMuteSfx([1])")
         wait_for_console_log(
+            logs,
             lambda text: "sfx mute button toggled to: true" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
         checked = page.evaluate("document.getElementById('mute-sfx').checked")
         assert checked, "SFX mute not toggled to unmuted"
@@ -299,8 +369,11 @@ def test_volume_sliders_mutes(page: Page) -> None:
         )
         page.evaluate("window.changeWeaponVolume([0.2])")
         wait_for_console_log(
-            lambda text: "applied loaded sfx_weapon volume to audioserver: 0.2" in text,
-            start_idx=pre_change_log_count,
+            logs,
+            lambda text: "applied loaded sfx_weapon volume to audioserver: 0.2"
+            in text,
+            pre_change_log_count,
+            page,
         )
         value = page.evaluate("document.getElementById('weapon-slider').value")
         assert value == "0.2", f"Weapon slider value not set to 0.2, got {value}"
@@ -308,24 +381,30 @@ def test_volume_sliders_mutes(page: Page) -> None:
         # VOL-08: Mute / unmute Weapon
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.toggleMuteWeapon !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteWeapon !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.toggleMuteWeapon([0])")
         wait_for_console_log(
+            logs,
             lambda text: "weapon is muted" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
         checked = page.evaluate("document.getElementById('mute-weapon').checked")
         assert not checked, "Weapon mute not toggled to muted"
 
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.toggleMuteWeapon !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteWeapon !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.toggleMuteWeapon([1])")
         wait_for_console_log(
+            logs,
             lambda text: "weapon mute button toggled to: true" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
         checked = page.evaluate("document.getElementById('mute-weapon').checked")
         assert checked, "Weapon mute not toggled to unmuted"
@@ -338,8 +417,11 @@ def test_volume_sliders_mutes(page: Page) -> None:
         )
         page.evaluate("window.changeRotorsVolume([0.9])")
         wait_for_console_log(
-            lambda text: "applied loaded sfx_rotors volume to audioserver: 0.9" in text,
-            start_idx=pre_change_log_count,
+            logs,
+            lambda text: "applied loaded sfx_rotors volume to audioserver: 0.9"
+            in text,
+            pre_change_log_count,
+            page,
         )
         value = page.evaluate("document.getElementById('rotors-slider').value")
         assert value == "0.9", f"Rotors slider value not set to 0.9, got {value}"
@@ -347,24 +429,30 @@ def test_volume_sliders_mutes(page: Page) -> None:
         # VOL-10: Mute / unmute Rotors
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.toggleMuteRotors !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteRotors !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.toggleMuteRotors([0])")
         wait_for_console_log(
+            logs,
             lambda text: "rotors is muted" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
         checked = page.evaluate("document.getElementById('mute-rotors').checked")
         assert not checked, "Rotors mute not toggled to muted"
 
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.toggleMuteRotors !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteRotors !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.toggleMuteRotors([1])")
         wait_for_console_log(
+            logs,
             lambda text: "rotors mute button toggled to: true" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
         checked = page.evaluate("document.getElementById('mute-rotors').checked")
         assert checked, "Rotors mute not toggled to unmuted"
@@ -372,12 +460,16 @@ def test_volume_sliders_mutes(page: Page) -> None:
         # VOL-11: Adjust Menu volume slider
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.changeMenuVolume !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.changeMenuVolume !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.changeMenuVolume([0.9])")
         wait_for_console_log(
-            lambda text: "applied loaded sfx_menu volume to audioserver: 0.9" in text,
-            start_idx=pre_change_log_count,
+            logs,
+            lambda text: "applied loaded sfx_menu volume to audioserver: 0.9"
+            in text,
+            pre_change_log_count,
+            page,
         )
         value = page.evaluate("document.getElementById('menu-slider').value")
         assert value == "0.9", f"Menu slider value not set to 0.9, got {value}"
@@ -385,24 +477,30 @@ def test_volume_sliders_mutes(page: Page) -> None:
         # VOL-12: Mute / unmute Menu
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.toggleMuteMenu !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteMenu !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.toggleMuteMenu([0])")
         wait_for_console_log(
+            logs,
             lambda text: "menu is muted" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
         checked = page.evaluate("document.getElementById('mute-menu').checked")
         assert not checked, "Menu mute not toggled to muted"
 
         pre_change_log_count = len(logs)
         page.wait_for_function(
-            "() => typeof window.toggleMuteMenu !== 'undefined'", timeout=TEST_TIMEOUT
+            "() => typeof window.toggleMuteMenu !== 'undefined'",
+            timeout=TEST_TIMEOUT,
         )
         page.evaluate("window.toggleMuteMenu([1])")
         wait_for_console_log(
+            logs,
             lambda text: "menu mute button toggled to: true" in text,
-            start_idx=pre_change_log_count,
+            pre_change_log_count,
+            page,
         )
         checked = page.evaluate("document.getElementById('mute-menu').checked")
         assert checked, "Menu mute not toggled to unmuted"

--- a/tests/volume_sliders_mutes_test.py
+++ b/tests/volume_sliders_mutes_test.py
@@ -32,28 +32,8 @@ from typing import Any, Callable
 import pytest
 from playwright.sync_api import Page, expect
 
-# Configuration for stability in different environments
-DEFAULT_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "30000"))
-TEST_TIMEOUT = int(os.getenv("TEST_TIMEOUT", "5000"))
-
-
-def wait_for_console_log(
-    logs: list[dict[str, str]],
-    predicate: Callable[[str], bool],
-    start_idx: int,
-    page: Page,
-    timeout_ms: int = TEST_TIMEOUT,
-) -> None:
-    """Helper to poll until a matching console log arrives or timeout expires."""
-    start_time = time.time()
-    while (time.time() - start_time) * 1000 < timeout_ms:
-        if any(predicate(log["text"].lower()) for log in logs[start_idx:]):
-            return
-        page.wait_for_timeout(50)  # Micro-poll for event loop progression
-    pytest.fail(
-        "Timed out waiting for expected console log matching "
-        f"predicate after {timeout_ms}ms"
-    )
+# Import shared utilities at the top of the file
+from tests.test_utils import DEFAULT_TIMEOUT, TEST_TIMEOUT, wait_for_console_log
 
 
 def _has_save_log(logs: list[dict[str, str]]) -> bool:

--- a/tests/volume_sliders_mutes_test.py
+++ b/tests/volume_sliders_mutes_test.py
@@ -52,6 +52,7 @@ def test_volume_sliders_mutes(page: Page) -> None:
     """
     logs: list[dict[str, str]] = []
     cdp_session = None
+    coverage_started = False
 
     def on_console(msg: Any) -> None:
         """
@@ -72,6 +73,7 @@ def test_volume_sliders_mutes(page: Page) -> None:
         cdp_session.send(
             "Profiler.startPreciseCoverage", {"callCount": True, "detailed": True}
         )
+        coverage_started = True
 
         page.goto(
             "http://localhost:8080/index.html",
@@ -488,9 +490,12 @@ def test_volume_sliders_mutes(page: Page) -> None:
                 f.write(f"[{log['type']}] {log['text']}\n")
         raise
     finally:
-        if cdp_session:
-            coverage = cdp_session.send("Profiler.takePreciseCoverage")["result"]
-            cdp_session.send("Profiler.stopPreciseCoverage")
-            cdp_session.send("Profiler.disable")
-            with open("v8_coverage_volume_sliders_mutes_test.json", "w") as f:
-                json.dump(coverage, f)
+        if cdp_session and coverage_started:
+            try:
+                coverage = cdp_session.send("Profiler.takePreciseCoverage")["result"]
+                cdp_session.send("Profiler.stopPreciseCoverage")
+                cdp_session.send("Profiler.disable")
+                with open("v8_coverage_volume_sliders_mutes_test.json", "w") as f:
+                    json.dump(coverage, f)
+            except Exception as cov_err:
+                print(f"Warning: Failed to harvest V8 coverage data: {cov_err}")

--- a/tests/volume_sliders_mutes_test.py
+++ b/tests/volume_sliders_mutes_test.py
@@ -29,7 +29,6 @@ import os
 import time
 from typing import Any, Callable
 
-import pytest
 from playwright.sync_api import Page, expect
 
 # Import shared utilities at the top of the file

--- a/tests/volume_sliders_mutes_test.py
+++ b/tests/volume_sliders_mutes_test.py
@@ -32,17 +32,12 @@ from typing import Any, Callable
 from playwright.sync_api import Page, expect
 
 # Import shared utilities at the top of the file
-from tests.test_utils import DEFAULT_TIMEOUT, TEST_TIMEOUT, wait_for_console_log
-
-
-def _has_save_log(logs: list[dict[str, str]]) -> bool:
-    """Check if any log entry indicates settings were saved."""
-    return any(
-        ("encrypted" in log["text"].lower() and "settings" in log["text"].lower())
-        or "falling back to plaintext" in log["text"].lower()
-        or "saved" in log["text"].lower()
-        for log in logs
-    )
+from tests.test_utils import (
+    DEFAULT_TIMEOUT,
+    TEST_TIMEOUT,
+    has_save_log,
+    wait_for_console_log,
+)
 
 
 def test_volume_sliders_mutes(page: Page) -> None:
@@ -303,7 +298,7 @@ def test_volume_sliders_mutes(page: Page) -> None:
         assert any(
             "sfx volume level in audiomanager: 0.8" in log["text"].lower()
             for log in sfx_logs
-        ) or _has_save_log(sfx_logs), "SFX volume side effect log missing"
+        ) or has_save_log(sfx_logs), "SFX volume side effect log missing"
         value = page.evaluate("document.getElementById('sfx-slider').value")
         assert value == "0.8", f"SFX slider value not set to 0.8, got {value}"
 

--- a/workspace/run_browser_tests.sh
+++ b/workspace/run_browser_tests.sh
@@ -10,10 +10,13 @@ PW_TIMEOUT=30000
 # Function to check if a step failed
 check_exit() {
   if [ $? -ne 0 ]; then
-    echo "Error in $1. Exiting pipeline."
+    echo "❌ Error in $1. Exiting pipeline."
     exit 1
   fi
 }
+
+# Ensure Git trusts the container directory to avoid dubious ownership errors
+git config --global --add safe.directory "$PROJECT_DIR" 2>/dev/null || true
 
 # 1. Inject a dummy salt (Pipeline consistency)
 echo "⚙️ Injecting dummy salt for Playwright tests..."
@@ -21,7 +24,6 @@ PRODUCTION_SALT="playwright_dummy_salt_123" bash .github/scripts/inject_salt.sh 
 check_exit "Salt Injection"
 
 # 2. FORCE the "ci" feature flag into export_presets.cfg
-# Godot 4 ignores CLI feature flags, so we must inject it into the preset directly
 echo "⚙️ Injecting 'ci' feature flag into export_presets.cfg..."
 python3 .github/scripts/inject_ci_flag.py
 check_exit "CI Flag Injection"
@@ -33,13 +35,11 @@ godot --headless --path "$PROJECT_DIR" --export-release "Web_thread_off" "$EXPOR
 check_exit "Godot Export"
 
 # 4. Clean up the repository
-# We strictly revert globals.gd and export_presets.cfg to keep your repo pristine
 echo "🧹 Restoring files to pristine state..."
-git restore export_presets.cfg
-git restore scripts/core/globals.gd
+git restore export_presets.cfg scripts/core/globals.gd
+check_exit "Repository Restore"
 
-# 5. Start a security-isolated web server
-# Provides the COOP and COEP headers absolutely required by Godot 4 Web exports
+# 5. Start a security-isolated web server with reliable cleanup trap
 echo "🚀 Starting security-isolated server on port $SERVER_PORT..."
 python3 -c "
 import http.server, socketserver, os
@@ -56,28 +56,45 @@ with socketserver.TCPServer(('', $SERVER_PORT), MyHandler) as httpd:
 " &
 SERVER_PID=$!
 
+# Trap process termination signals to ensure background server cleanup
+trap 'kill $SERVER_PID 2>/dev/null || true' EXIT INT TERM
+
 echo "Waiting for server to respond..."
-max_retries=20
+max_retries=100
 count=0
-while ! curl -s http://localhost:$SERVER_PORT/index.html > /dev/null; do
-  sleep 1
-  count=$((count + 1))
-  if [ $count -eq $max_retries ]; then
-    echo "❌ Server failed to start"
-    kill $SERVER_PID
-    exit 1
+server_ready=0
+
+while [ $count -lt $max_retries ]; do
+  if curl -s http://localhost:$SERVER_PORT/index.html > /dev/null; then
+    server_ready=1
+    break
   fi
+  sleep 0.2
+  count=$((count + 1))
 done
+
+if [ $server_ready -eq 0 ]; then
+  echo "❌ Server failed to start within timeout"
+  exit 1
+fi
 echo "✅ Server ready"
 
 # 6. Run Playwright tests
 echo "🧪 Running Playwright Browser Tests..."
 mkdir -p "$PROJECT_DIR/artifacts"
 source /opt/venv/bin/activate
-xvfb-run --auto-servernum --server-args="-screen 0 1280x720x24" pytest tests/ -v --timeout=$PW_TIMEOUT --ignore=tests/refactor --ignore=tests/ci --capture=no --html="$PROJECT_DIR/report.html" --self-contained-html --junitxml="$PROJECT_DIR/report.xml"
+xvfb-run --auto-servernum --server-args="-screen 0 1280x720x24" pytest tests/ \
+  -v \
+  --timeout=$PW_TIMEOUT \
+  --ignore=tests/refactor \
+  --ignore=tests/ci \
+  --capture=no \
+  --html="$PROJECT_DIR/report.html" \
+  --self-contained-html \
+  --junitxml="$PROJECT_DIR/report.xml"
 check_exit "Playwright Tests"
 
-# Generate test report summary
+# 7. Generate test report summary
 if [ -f "$PROJECT_DIR/report.xml" ]; then
   total=$(xmllint --xpath 'count(//testcase)' "$PROJECT_DIR/report.xml")
   failures=$(xmllint --xpath 'count(//testcase/failure)' "$PROJECT_DIR/report.xml")
@@ -93,6 +110,3 @@ if [ -f "$PROJECT_DIR/report.xml" ]; then
 else
   echo "No report.xml found—tests may not have run."
 fi
-
-# Cleanup
-kill $SERVER_PID

--- a/workspace/run_browser_tests.sh
+++ b/workspace/run_browser_tests.sh
@@ -74,7 +74,8 @@ count=0
 server_ready=0
 
 while [ $count -lt $max_retries ]; do
-  if curl -s http://localhost:$SERVER_PORT/index.html > /dev/null; then
+  if curl --fail --silent --show-error --max-time 1 \
+      "http://localhost:${SERVER_PORT}/index.html" > /dev/null; then
     server_ready=1
     break
   fi

--- a/workspace/run_browser_tests.sh
+++ b/workspace/run_browser_tests.sh
@@ -39,7 +39,16 @@ echo "🧹 Restoring files to pristine state..."
 git restore export_presets.cfg scripts/core/globals.gd
 check_exit "Repository Restore"
 
-# 5. Start a security-isolated web server with reliable cleanup trap
+cleanup_server() {
+  if [ -n "${SERVER_PID:-}" ]; then
+    kill "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+}
+
+trap cleanup_server EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 echo "🚀 Starting security-isolated server on port $SERVER_PORT..."
 python3 -c "
 import http.server, socketserver, os


### PR DESCRIPTION
Refactor test infrastructure for improved reliability:

- Split fixture setup: session-scoped browser launch + function-scoped page contexts for better isolation and startup overhead reduction
- Replace all page.wait_for_timeout() calls with deterministic page.wait_for_function() checks or expect() assertions
- Add wait_for_console_log() helper to poll for matching console logs with predicates instead of fixed waits
- Improve Godot initialization check: use explicit '=== true' instead of loose truthy check
- Use expect() API for DOM element visibility assertions (canvas, buttons)
- Add type hints to function parameters and imports (Any, Callable, Generator)
- Improve shell script: better signal handling, robust server startup checks, git safety config
- Remove verbose/redundant comments to improve readability

These changes eliminate timing-dependent flakiness common in browser automation by making assertions wait for actual state changes rather than arbitrary durations.

---
name: Default Pull Request Template
about: Suggesting changes to SkyLockAssault
title: ''
labels: ''
assignees: ''
---

## PR #845 Summary: Replace brittle waits with deterministic polling

**Repository:** [ikostan/SkyLockAssault](https://github.com/ikostan/SkyLockAssault)  
**Author:** @ikostan  
**Branch:** `code-audits-asynchronous-refactoring` → `main`  
**Linked Issue:** [#772 – [TASK] Code Audits & Asynchronous Refactoring](https://github.com/ikostan/SkyLockAssault/issues/772)  
**Milestone:** Milestone 22 – Optimize Test Suite Runtime & Fix Loading Screen  
**Labels:** `enhancement`, `testing`, `refactoring`, `python`, `QA`

### Purpose
Eliminate timing-dependent flakiness in the Playwright browser E2E test suite by replacing all fixed-duration waits (`page.wait_for_timeout()`, arbitrary sleeps) with deterministic, state-based synchronization. The changes make tests wait for actual engine readiness, DOM visibility, or console-log events instead of relying on brittle timeouts.

### Core Improvements

#### 1. Deterministic Waiting & Assertions
- Replaced every `page.wait_for_timeout()` with:
  - `page.wait_for_function()` for Godot initialization (`window.godotInitialized === true`) and DOM style/display checks
  - Playwright `expect(locator).to_be_visible()` for canvas, buttons, and overlays
- Introduced reusable `wait_for_console_log(logs, predicate, start_idx, page)` helper that polls captured console messages with a predicate until the condition is met or a timeout occurs
- Standardized console-log assertions (lower-cased matching, structured waiting) across volume, reset, audio, difficulty, back-navigation, and navigation tests
- Strict equality check for Godot readiness (`=== true` instead of truthy)

#### 2. Shared Test Utilities & Fixtures
- Extracted common helpers and timeout constants into new module `tests/test_utils.py`
- Centralized `DEFAULT_TIMEOUT` / `TEST_TIMEOUT` (environment-configurable)
- Restructured `tests/conftest.py`:
  - Session-scoped `browser_instance` fixture (single Chromium launch with GPU/WebGL flags)
  - Function-scoped isolated `BrowserContext` + `Page` per test
  - Optional HAR recording support via marker
  - Full type annotations (`Browser`, `BrowserContext`, `Page`, `Generator`, etc.)

#### 3. Test Coverage Stabilization
Affected test files (all converted to deterministic waits):
- `tests/audio_flow_test.py`
- `tests/volume_sliders_mutes_test.py`
- `tests/reset_audio_flow_test.py`
- `tests/difficulty_flow_test.py`
- `tests/back_flow_test.py`
- `tests/navigation_to_audio_test.py`
- `tests/load_main_menu_test.py`
- `tests/no_error_logs_test.py`
- `tests/validate_clean_load_test.py`

Improvements include:
- Explicit waiting for callback availability (`window.xxxPressed`)
- Verification of menu transitions via `getComputedStyle(...).display`
- Persistence checks after back-navigation and slider changes
- Stricter “no unexpected errors” verification with clearer failure diagnostics (screenshots + captured logs)

#### 4. Browser Test Runner Hardening (`workspace/run_browser_tests.sh`)
- Added `git config --global --add safe.directory` to avoid “dubious ownership” errors in containers
- Simplified and made robust the `git restore` of `export_presets.cfg` and `globals.gd`
- Signal-aware cleanup (`trap` on `EXIT`/`INT`/`TERM`) for the background HTTP server
- Increased server readiness polling frequency and timeout with clearer failure messages
- Improved pytest invocation formatting and report-generation comments
- Removed manual `kill` of server PID in favor of trap-based cleanup

#### 5. Code Quality & Maintainability
- Added comprehensive type hints (`Any`, `Callable`, `Generator`, `Dict`, `List`, `Optional`)
- Removed verbose/redundant comments and outdated docstrings
- Normalized imports and formatting (multiple Black + isort passes)
- Extracted duplicated helpers (e.g. `has_save_log`) into the shared utility module

### Benefits
- Dramatically reduced flakiness caused by race conditions and variable load times
- Faster overall suite runtime (shared browser launch + tighter, condition-driven waits)
- Better isolation between tests while keeping startup overhead low
- Clearer failure diagnostics and more maintainable test code
- Improved CI reliability for browser-based E2E runs

### AI / Bot Assistance (for reference)
- **@sourcery-ai** – PR summary, Reviewer’s Guide, and code-review feedback
- **@coderabbitai** – PR summary, walkthrough, multiple review rounds, and co-authored commits on the runner script
- **@deepsource-io** – Automated code review + PR Report Card
- **@deepsource-autofix** – Multiple automated Black/isort formatting commits

### Status Notes
The PR fully addresses the objectives of issue #772 regarding wait refactoring, fixture lifecycle optimization, and runner robustness.

---

## Related Issue

Closes #ISSUE_NUMBER (if applicable)

## Changes

- [x] List key changes here (e.g., "Updated Jump.gd to use Godot 4.4's new Tween
  system")
- [x] Any breaking changes? (e.g., "Deprecated old signal; migrate to new one")

## Testing

- [x] Ran the game in Godot v4.5 editor—describe what you tested (e.g., "Jump
  works on Win10 with 60 FPS")
- [x] Any new unit tests added? (Link to test scene if yes)
- [x] Screenshots/GIFs if UI-related: (Attach below)

## Checklist

- [x] Code follows Godot style guide (e.g., snake_case for variables)
- [x] No console errors in editor/output
- [x] Ready for review!

## Additional Notes

Anything else? (e.g., "Tested on Win10 64-bit; needs Linux validation")

## Summary by Sourcery

Refactor browser E2E test suite to use deterministic state-based waits instead of fixed timeouts for Godot initialization, UI visibility, and log-driven flows, improving reliability and reducing flakiness.

Enhancements:
- Introduce a reusable wait_for_console_log helper across tests to poll for specific console output instead of relying on arbitrary delays.
- Update all Playwright tests to assert DOM visibility and state using expect() and wait_for_function calls with explicit conditions, including strict Godot initialization checks.
- Restructure pytest fixtures to share a session-scoped Chromium browser and per-test contexts, reducing startup overhead while preserving isolation.
- Simplify and tighten test assertions by removing redundant manual log scanning and unnecessary comments.
- Improve the browser test runner script with safer git restore behavior, robust server startup polling, signal-aware cleanup, and clearer reporting output.

Build:
- Refine run_browser_tests.sh to better manage Godot export, server lifecycle, and Playwright execution under CI-friendly settings.

Tests:
- Stabilize audio, volume, reset, difficulty, navigation, and back-flow tests by replacing brittle wait_for_timeout usage with deterministic UI and console-log checks.
- Ensure load and error-free startup tests validate canvas visibility and Godot readiness via explicit expect and wait_for_function conditions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved browser-based E2E stability across main-menu, navigation-to-audio, back-navigation, audio reset, volume sliders/mutes, and difficulty flows by replacing fixed waits with deterministic engine/UI readiness checks.
  * Standardized log-driven synchronization using shared helpers, with stricter “no unexpected errors” verification and clearer failure diagnostics (screenshots plus captured console logs/artifacts).
  * Centralized environment-configurable timeouts for consistent waiting behavior.
* **Chores**
  * Added shared E2E test utilities and updated fixtures to reuse a single headless browser per run while keeping isolated contexts per test.
  * Hardened the browser test runner’s server lifecycle management and repository cleanup/restore behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### AI / Bot Contributors

- **@sourcery-ai**  
  Generated the PR summary and Reviewer's Guide. Performed code review identifying duplication of `wait_for_console_log`, suggesting extraction to a shared utility, recommending Playwright locator assertions over raw JS `wait_for_function` checks, and noting potential tracing cleanup for session-scoped browser fixtures.

- **@coderabbitai**  
  Generated the PR summary and detailed walkthrough. Conducted multiple rounds of code review with actionable suggestions (timeout centralization, helper extraction, assertion improvements, shell-script hardening). Co-authored commits updating `workspace/run_browser_tests.sh`.

- **@deepsource-io**  
  Performed automated code review, published a PR Report Card (Security / Reliability / Complexity / Hygiene), and provided analysis status for Python and JavaScript.

- **@deepsource-autofix**  
  Authored multiple automated style/format commits (`style: format code with Black and isort`) to enforce formatting consistency across test files.

### Human Contributor

- **@ikostan**  
  Primary author of the PR. Implemented the core refactor (deterministic polling with `wait_for_function` / `expect()`, `wait_for_console_log` helper, session-scoped browser + function-scoped contexts, type hints, and hardened `run_browser_tests.sh`). Authored the majority of commits, addressed review feedback, extracted shared utilities to `tests/test_utils.py`, and created supporting documentation.

---